### PR TITLE
Wrapper for fvs run, DLL close method

### DIFF
--- a/fvs2py/__init__.py
+++ b/fvs2py/__init__.py
@@ -1,0 +1,3 @@
+from ._base import FVS
+
+__all__ = ["FVS"]

--- a/fvs2py/_base.py
+++ b/fvs2py/_base.py
@@ -15,6 +15,9 @@ class FVS(FvsCore):
         self._itrncd = ct.c_int(-1)
         self.keyfile: str | None = None
         self.keyfile_path: Path | None = None
+        self._stop_point_code = None
+        self._stop_point_year = None
+        self._restart_code = ct.c_int(0)
 
     @property
     def itrncd(self) -> int:
@@ -33,6 +36,59 @@ class FVS(FvsCore):
         self._fvsGetRtnCode(self._itrncd)
 
         return self._itrncd.value
+
+    @property
+    def restart_code(self) -> int:
+        """A code indicating when FVS stopped.
+
+          1: Stop was done just before the first call to the Event Monitor.
+          2: Stop was done just after the first call to the Event Monitor.
+          3: Stop was done just before the second call to the Event Monitor.
+          4: Stop was done just after the second call to the Event Monitor.
+          5: Stop was done after growth and mortality has been computed, but
+                prior to applying them.
+          6: Stop was done just before the ESTAB routines are called.
+        100: Stop was done after a stand has been simulated but prior to
+                starting a subsequent stand.
+        """
+        self._fvsGetRestartCode.argtypes = [ct.POINTER(ct.c_int)]
+        self._fvsGetRestartCode.restype = None
+        self._fvsGetRestartCode(self._restart_code)
+
+        return self._restart_code.value
+
+    @property
+    def stop_point_code(self) -> int | None:
+        """A code used to instruct FVS when to stop during a cycle.
+
+        -1 : Stop at every stop location.
+         0 : Never stop.
+         1 : Stop just before the first call to the Event Monitor.
+         2 : Stop just after the first call to the Event Monitor.
+         3 : Stop just before the second call to the Event Monitor.
+         4 : Stop just after the second call to the Event Monitor.
+         5 : Stop after growth and mortality has been computed, but prior to
+                applying them.
+         6 : Stop just before the ESTAB routines are called.
+         7 : Stop just after input is read but before missing values are imputed
+                (tree heights and crown ratios, for example) and model
+                calibration (argument stptyr is ignored).
+        """
+        if self._stop_point_code is not None:
+            return self._stop_point_code.value
+        return None
+
+    @property
+    def stop_point_year(self) -> int | None:
+        """A code indicating which cycles FVS should stop at.
+
+        0 : Never stop.
+        1 : Stop at every cycle.
+        YYYY : A specific year during the simulation period.
+        """
+        if self._stop_point_year is not None:
+            return self._stop_point_year.value
+        return None
 
     def load_keyfile(self, keywordfile: str | os.PathLike) -> None:
         """Sets the keywordfile as a command line argument to FVS.
@@ -56,5 +112,122 @@ class FVS(FvsCore):
 
         self._fvsSetCmdLine(cmdline.encode(), ct.c_int(nch), self._itrncd)
         logging.debug(f"Return code updated to {self.itrncd}")
+
+        return
+
+    def set_stop_point_codes(
+        self,
+        stop_point_code: int | None = None,
+        stop_point_year: int | None = None,
+    ) -> None:
+        """Sets FVS stop point codes.
+
+        Args:
+            stop_point_code (int): Optional code for when FVS should stop during
+                a cycle:
+               -1 : Stop at every stop location
+                0 : Never stop
+                1 : Stop just before the first call to the Event Monitor
+                2 : Stop just after the first call to the Event Monitor
+                3 : Stop just before the second call to the Event Monitor
+                4 : Stop just after the second call to the Event Monitor
+                5 : Stop after growth and mortality has been computed, but
+                        prior to applying them
+                6 : Stop just before the ESTAB routines are called
+                7 : Stop just after input is read but before missing values
+                        are imputed
+            stop_point_year (int): Optional, years FVS should stop, options are:
+                0 : Never stop
+               -1 : Stop at every cycle
+               YYYY : A specific year during the simulation period
+        """
+        self._fvsSetStoppointCodes.argtypes = [
+            ct.POINTER(ct.c_int),
+            ct.POINTER(ct.c_int),
+        ]
+        self._fvsSetStoppointCodes.restype = None
+
+        if stop_point_code is not None:
+            if stop_point_code in range(-1, 8):
+                self._stop_point_code = ct.c_int(stop_point_code)  # type: ignore[assignment]
+            else:
+                msg = "Invalid value for stop_point_code"
+                raise ValueError(msg)
+        elif self._stop_point_code is None:
+            self._stop_point_code = ct.c_int(0)  # type: ignore[assignment]
+
+        if stop_point_year is not None:
+            if stop_point_code is not None:
+                self._stop_point_year = ct.c_int(stop_point_year)  # type: ignore[assignment]
+            else:
+                msg = (
+                    "Must specify stop_point_year if also specifying "
+                    "stop_point_code"
+                )
+                raise ValueError(msg)
+        elif self._stop_point_year is None:
+            self._stop_point_year = ct.c_int(0)  # type: ignore[assignment]
+
+        self._fvsSetStoppointCodes(self._stop_point_code, self._stop_point_year)
+
+        return
+
+    def run(
+        self,
+        stop_point_code: int | None = None,
+        stop_point_year: int | None = None,
+    ) -> None:
+        """Runs FVS.
+
+        Note that stopping after the simulation of each stand in a simulation is
+        done even when no stop request has been scheduled (that is, FVS will
+        return at the end of each stand in a simulation even if there are no
+        stop codes specified). Once a stand has been fully processed by FVS, the
+        FVS `restart_code` is set to 100 and the call to run() returns.
+
+        If there are multiple stands in a single keyfile, the simulation of the
+        next stand can be triggered by calling run() again.
+
+        The main output text file may be truncated even after the last stand has
+        been simulated. To conclude FVS writing to the main output file, call
+        run() one last time. The `itrncd` attribute should then change to a
+        value of 2, indicating all stands have been processed.
+
+        Args:
+            stop_point_code (optional, int): when FVS should stop during a cycle:
+               -1 : Stop at every stop location
+                0 : Never stop
+                1 : Stop just before the first call to the Event Monitor
+                2 : Stop just after the first call to the Event Monitor
+                3 : Stop just before the second call to the Event Monitor
+                4 : Stop just after the second call to the Event Monitor
+                5 : Stop after growth and mortality has been computed, but
+                        prior to applying them
+                6 : Stop just before the ESTAB routines are called
+                7 : Stop just after input is read but before missing values
+                        are imputed
+            stop_point_year (optional, int): years FVS should stop, options are:
+                0 : Never stop
+               -1 : Stop at every cycle
+               YYYY : A specific year during the simulation period
+        """
+        self._fvs.argtypes = [ct.POINTER(ct.c_int)]
+        self._fvs.restype = None
+
+        if self.keyfile is None:
+            msg = "No keyfile loaded yet."
+            raise AttributeError(msg)
+        logging.debug("Found keyfile.")
+        self.set_stop_point_codes(stop_point_code, stop_point_year)
+        logging.debug(
+            f"Set stop point codes, {stop_point_code}:{self.stop_point_code}, {stop_point_year}:{self.stop_point_year}"
+        )
+        while self.itrncd == 0:
+            logging.debug("itrncd still zero.")
+            self._fvs(self._itrncd)
+            logging.debug(f"Ran _fvs routine, itrncd is {self.itrncd}")
+            if self.restart_code != 0:
+                logging.debug("restart code not zero... halting run.")
+                break
 
         return

--- a/fvs2py/_core.py
+++ b/fvs2py/_core.py
@@ -34,8 +34,8 @@ class FvsCore:
                 getattr(self._lib, routine)
             ):
                 logging.debug(f"Found {routine} as expected.")
-            # anticipate subroutine name changes depending upon compiler and OS
-            # unix pattern on fortran functions
+                # anticipate subroutine name changes depending upon compiler and OS
+                # unix pattern on fortran functions
             elif hasattr(self._lib, f"{routine.lower()}_") and callable(
                 getattr(self._lib, f"{routine.lower()}_")
             ):

--- a/fvs2py/_core.py
+++ b/fvs2py/_core.py
@@ -94,3 +94,10 @@ class FvsCore:
             self._fvsUnitConversion = self._lib.fvsUnitConversion
 
         return
+
+    def _close(self):
+        """Unloads the FVS DLL."""
+        close_func = self._lib.dlclose
+        close_func.argtypes = (ct.c_void_p,)
+        close_func.restype = ct.c_int
+        close_func(self._lib._handle)

--- a/fvs2py/tests/Dockerfile
+++ b/fvs2py/tests/Dockerfile
@@ -25,4 +25,4 @@ RUN pip install --upgrade pip pip-tools &&\
  pip install --no-cache-dir --upgrade -r /code/requirements-dev.txt
 COPY fvs2py /code/fvs2py
 
-CMD ["pytest", "-n",  "auto", "fvs2py"]
+CMD ["pytest", "fvs2py"]

--- a/fvs2py/tests/Dockerfile
+++ b/fvs2py/tests/Dockerfile
@@ -25,4 +25,4 @@ RUN pip install --upgrade pip pip-tools &&\
  pip install --no-cache-dir --upgrade -r /code/requirements-dev.txt
 COPY fvs2py /code/fvs2py
 
-CMD ["pytest", "fvs2py"]
+CMD ["pytest", "-n",  "auto", "fvs2py"]

--- a/fvs2py/tests/test_base.py
+++ b/fvs2py/tests/test_base.py
@@ -18,13 +18,9 @@ FVS_ITRNCD_GOOD_RUNNING_STATE = 0
 FVS_ITRNCD_FINISHED_ALL_STANDS = 2
 
 
-@pytest.fixture
-def fvs():
-    return FVS(TEST_DLL)
-
-
-def test_load_keyfile(fvs, tmp_path):
+def test_load_keyfile(tmp_path):
     """Checks that keyfile attributes get populated and itrncd updates."""
+    fvs = FVS(TEST_DLL)
     assert fvs.itrncd == FVS_ITRNCD_NOT_STARTED
     assert fvs.keyfile is None
     assert fvs.keyfile_path is None
@@ -40,8 +36,9 @@ def test_load_keyfile(fvs, tmp_path):
     assert fvs.keyfile == TEST_KEYFILE_PATH.read_text()
 
 
-def test_stop_points(fvs):
+def test_stop_points():
     """Checks that stop point code and year works."""
+    fvs = FVS(TEST_DLL)
     assert fvs.stop_point_code is None
     assert fvs.stop_point_year is None
 
@@ -50,7 +47,8 @@ def test_stop_points(fvs):
     assert fvs.stop_point_year == 0
 
 
-def test_stop_point_year_without_stop_point_code(fvs):
+def test_stop_point_year_without_stop_point_code():
+    fvs = FVS(TEST_DLL)
     assert fvs.stop_point_code is None
     assert fvs.stop_point_year is None
     match_msg = (
@@ -61,7 +59,8 @@ def test_stop_point_year_without_stop_point_code(fvs):
 
 
 @pytest.mark.parametrize("stop_point_code", range(-2, 10))
-def test_invalid_stop_point_code(fvs, stop_point_code):
+def test_invalid_stop_point_code(stop_point_code):
+    fvs = FVS(TEST_DLL)
     assert fvs.stop_point_code is None
     assert fvs.stop_point_year is None
     match_msg = "Invalid value for stop_point_code"
@@ -74,7 +73,8 @@ def test_invalid_stop_point_code(fvs, stop_point_code):
         assert fvs.stop_point_year == 0
 
 
-def test_run_with_keyfile_succeeds(fvs, tmp_path):
+def test_run_with_keyfile_succeeds(tmp_path):
+    fvs = FVS(TEST_DLL)
     assert fvs.itrncd == FVS_ITRNCD_NOT_STARTED
     keyfile_content = TEST_KEYFILE_PATH.read_text()
     keyfile_to_run = tmp_path / "test_keyfile.key"
@@ -92,12 +92,14 @@ def test_run_with_keyfile_succeeds(fvs, tmp_path):
     assert os.path.exists(f"{tmp_path}/test_keyfile.out")
 
 
-def test_run_without_keyfile_raises(fvs):
+def test_run_without_keyfile_raises():
+    fvs = FVS(TEST_DLL)
     with pytest.raises(AttributeError, match="No keyfile loaded yet."):
         fvs.run()
 
 
-def test_restart_codes_match_stop_point_codes(fvs, tmp_path):
+def test_restart_codes_match_stop_point_codes(tmp_path):
+    fvs = FVS(TEST_DLL)
     assert fvs.itrncd == FVS_ITRNCD_NOT_STARTED
     assert fvs.stop_point_code is None
     assert fvs.stop_point_year is None

--- a/fvs2py/tests/test_base.py
+++ b/fvs2py/tests/test_base.py
@@ -1,4 +1,7 @@
 import importlib.resources
+import os
+
+import pytest
 
 from fvs2py._base import FVS
 
@@ -6,15 +9,117 @@ TEST_DLL = "/usr/local/lib/FVSso.so"
 TEST_KEYFILE_PATH = importlib.resources.files("fvs2py.tests.keyfiles").joinpath(
     "SO.key"
 )
+FVS_RESTART_CODE_DONE_RUNNING_STAND = 100
+FVS_RESTART_CODE_INITIALIZED = 0
+FVS_STOP_POINT_CODE_AFTER_FIRST_EVMON = 2
+
+FVS_ITRNCD_NOT_STARTED = -1
+FVS_ITRNCD_GOOD_RUNNING_STATE = 0
+FVS_ITRNCD_FINISHED_ALL_STANDS = 2
 
 
-def test_load_keyfile():
+@pytest.fixture
+def fvs():
+    return FVS(TEST_DLL)
+
+
+def test_load_keyfile(fvs, tmp_path):
     """Checks that keyfile attributes get populated and itrncd updates."""
-    fvs = FVS(TEST_DLL)
-    assert fvs.itrncd == -1
+    assert fvs.itrncd == FVS_ITRNCD_NOT_STARTED
     assert fvs.keyfile is None
     assert fvs.keyfile_path is None
-    fvs.load_keyfile(TEST_KEYFILE_PATH)
-    assert fvs.itrncd == 0
-    assert fvs.keyfile_path == TEST_KEYFILE_PATH
+    keyfile_content = TEST_KEYFILE_PATH.read_text()
+    keyfile_to_run = tmp_path / "test_keyfile.key"
+
+    with open(keyfile_to_run, "w") as f:
+        f.write(keyfile_content)
+
+    fvs.load_keyfile(keyfile_to_run)
+    assert fvs.itrncd == FVS_ITRNCD_GOOD_RUNNING_STATE
+    assert fvs.keyfile_path == keyfile_to_run
     assert fvs.keyfile == TEST_KEYFILE_PATH.read_text()
+
+
+def test_stop_points(fvs):
+    """Checks that stop point code and year works."""
+    assert fvs.stop_point_code is None
+    assert fvs.stop_point_year is None
+
+    fvs.set_stop_point_codes(-1, 0)
+    assert fvs.stop_point_code == -1
+    assert fvs.stop_point_year == 0
+
+
+def test_stop_point_year_without_stop_point_code(fvs):
+    assert fvs.stop_point_code is None
+    assert fvs.stop_point_year is None
+    match_msg = (
+        "Must specify stop_point_year if also specifying stop_point_code"
+    )
+    with pytest.raises(ValueError, match=match_msg):
+        fvs.set_stop_point_codes(None, 0)
+
+
+@pytest.mark.parametrize("stop_point_code", range(-2, 10))
+def test_invalid_stop_point_code(fvs, stop_point_code):
+    assert fvs.stop_point_code is None
+    assert fvs.stop_point_year is None
+    match_msg = "Invalid value for stop_point_code"
+    if stop_point_code not in range(-1, 8):
+        with pytest.raises(ValueError, match=match_msg):
+            fvs.set_stop_point_codes(stop_point_code, 0)
+    else:
+        fvs.set_stop_point_codes(stop_point_code, 0)
+        assert fvs.stop_point_code == stop_point_code
+        assert fvs.stop_point_year == 0
+
+
+def test_run_with_keyfile_succeeds(fvs, tmp_path):
+    assert fvs.itrncd == FVS_ITRNCD_NOT_STARTED
+    keyfile_content = TEST_KEYFILE_PATH.read_text()
+    keyfile_to_run = tmp_path / "test_keyfile.key"
+
+    with open(keyfile_to_run, "w") as f:
+        f.write(keyfile_content)
+
+    fvs.load_keyfile(keyfile_to_run)
+    assert fvs.restart_code == FVS_RESTART_CODE_INITIALIZED
+    fvs.run()
+    assert fvs.restart_code == FVS_RESTART_CODE_DONE_RUNNING_STAND
+    assert fvs.itrncd == FVS_ITRNCD_GOOD_RUNNING_STATE
+    fvs.run()
+    assert fvs.itrncd == FVS_ITRNCD_FINISHED_ALL_STANDS
+    assert os.path.exists(f"{tmp_path}/test_keyfile.out")
+
+
+def test_run_without_keyfile_raises(fvs):
+    with pytest.raises(AttributeError, match="No keyfile loaded yet."):
+        fvs.run()
+
+
+def test_restart_codes_match_stop_point_codes(fvs, tmp_path):
+    assert fvs.itrncd == FVS_ITRNCD_NOT_STARTED
+    assert fvs.stop_point_code is None
+    assert fvs.stop_point_year is None
+    assert fvs.restart_code == FVS_RESTART_CODE_INITIALIZED
+
+    keyfile_content = TEST_KEYFILE_PATH.read_text()
+    keyfile_to_run = tmp_path / "test_keyfile.key"
+
+    with open(keyfile_to_run, "w") as f:
+        f.write(keyfile_content)
+
+    fvs.load_keyfile(keyfile_to_run)
+    assert fvs.restart_code == FVS_RESTART_CODE_INITIALIZED
+    fvs.run(
+        stop_point_code=FVS_STOP_POINT_CODE_AFTER_FIRST_EVMON,
+        stop_point_year=2010,
+    )
+    assert fvs.restart_code == FVS_STOP_POINT_CODE_AFTER_FIRST_EVMON
+    assert fvs.itrncd == FVS_ITRNCD_GOOD_RUNNING_STATE
+    fvs.run()
+    assert fvs.restart_code == FVS_RESTART_CODE_DONE_RUNNING_STAND
+    assert fvs.itrncd == FVS_ITRNCD_GOOD_RUNNING_STATE
+    fvs.run()
+    assert fvs.itrncd == FVS_ITRNCD_FINISHED_ALL_STANDS
+    assert os.path.exists(f"{tmp_path}/test_keyfile.out")

--- a/fvs2py/tests/test_base.py
+++ b/fvs2py/tests/test_base.py
@@ -34,6 +34,7 @@ def test_load_keyfile(tmp_path):
     assert fvs.itrncd == FVS_ITRNCD_GOOD_RUNNING_STATE
     assert fvs.keyfile_path == keyfile_to_run
     assert fvs.keyfile == TEST_KEYFILE_PATH.read_text()
+    fvs._close()
 
 
 def test_stop_points():
@@ -45,6 +46,7 @@ def test_stop_points():
     fvs.set_stop_point_codes(-1, 0)
     assert fvs.stop_point_code == -1
     assert fvs.stop_point_year == 0
+    fvs._close()
 
 
 def test_stop_point_year_without_stop_point_code():
@@ -56,6 +58,7 @@ def test_stop_point_year_without_stop_point_code():
     )
     with pytest.raises(ValueError, match=match_msg):
         fvs.set_stop_point_codes(None, 0)
+    fvs._close()
 
 
 @pytest.mark.parametrize("stop_point_code", range(-2, 10))
@@ -71,6 +74,7 @@ def test_invalid_stop_point_code(stop_point_code):
         fvs.set_stop_point_codes(stop_point_code, 0)
         assert fvs.stop_point_code == stop_point_code
         assert fvs.stop_point_year == 0
+    fvs._close()
 
 
 def test_run_with_keyfile_succeeds(tmp_path):
@@ -90,12 +94,14 @@ def test_run_with_keyfile_succeeds(tmp_path):
     fvs.run()
     assert fvs.itrncd == FVS_ITRNCD_FINISHED_ALL_STANDS
     assert os.path.exists(f"{tmp_path}/test_keyfile.out")
+    fvs._close()
 
 
 def test_run_without_keyfile_raises():
     fvs = FVS(TEST_DLL)
     with pytest.raises(AttributeError, match="No keyfile loaded yet."):
         fvs.run()
+    fvs._close()
 
 
 def test_restart_codes_match_stop_point_codes(tmp_path):
@@ -125,3 +131,4 @@ def test_restart_codes_match_stop_point_codes(tmp_path):
     fvs.run()
     assert fvs.itrncd == FVS_ITRNCD_FINISHED_ALL_STANDS
     assert os.path.exists(f"{tmp_path}/test_keyfile.out")
+    fvs._close()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,5 @@ ipykernel
 pre-commit
 pytest
 pytest-mock
+pytest-xdist[psutil]
 ruff

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,4 @@ ipykernel
 pre-commit
 pytest
 pytest-mock
-pytest-xdist[psutil]
 ruff


### PR DESCRIPTION
Implements `_fvs` API call, including checks on restart codes, stop point codes, and internal return status. Adds _close method to FvsCore to handle unloading of DLLs to avoid persistence of attributes in a pytest session (e.g., internal return code does not reset to -1 each time the DLL is loaded). 