### PR TITLE
move ctypes signature definitions to a separate module

### DIFF
--- a/fvs2py/_base.py
+++ b/fvs2py/_base.py
@@ -9,7 +9,7 @@ import numpy.typing as npt
 import pandas as pd
 
 from fvs2py._core import FvsCore
-from fvs2py.common import class_requires_fvs_library, fvs_property
+from fvs2py.common import call_out, class_requires_fvs_library, fvs_property
 from fvs2py.constants import (
     FVS_ITRNCD_FINISHED_ALL_STANDS,
     FVS_ITRNCD_NOT_STARTED,
@@ -63,37 +63,18 @@ class FVS(FvsCore):
     @fvs_property
     def dims(self) -> dict:
         """Return the max dimensions of important FVS data storage."""
-        self._fvsDimSizes.argtypes = [
-            ct.POINTER(ct.c_int),
-            ct.POINTER(ct.c_int),
-            ct.POINTER(ct.c_int),
-            ct.POINTER(ct.c_int),
-            ct.POINTER(ct.c_int),
-            ct.POINTER(ct.c_int),
-            ct.POINTER(ct.c_int),
-        ]
-        self._fvsDimSizes.restype = None
-
-        self._dims = {
-            STR_NTREES: self._ntrees,
-            STR_NCYCLES: self._ncycles,
-            STR_NPLOTS: self._nplots,
-            STR_MAXTREES: self._maxtrees,
-            STR_MAXSPECIES: self._maxspecies,
-            STR_MAXPLOTS: self._maxplots,
-            STR_MAXCYCLES: self._maxcycles,
-        }
-
-        self._fvsDimSizes(
-            self._ntrees,
-            self._ncycles,
-            self._nplots,
-            self._maxtrees,
-            self._maxspecies,
-            self._maxplots,
-            self._maxcycles,
+        ntrees, ncycles, nplots, maxtrees, maxspecies, maxplots, maxcycles = (
+            call_out(self._fvsDimSizes, out_types=(ct.c_int,) * 7)
         )
-        return {key: val.value for key, val in self._dims.items()}
+        return {
+            STR_NTREES: ntrees,
+            STR_NCYCLES: ncycles,
+            STR_NPLOTS: nplots,
+            STR_MAXTREES: maxtrees,
+            STR_MAXSPECIES: maxspecies,
+            STR_MAXPLOTS: maxplots,
+            STR_MAXCYCLES: maxcycles,
+        }
 
     @fvs_property
     def exit_code(self) -> int:
@@ -106,11 +87,7 @@ class FVS(FvsCore):
           3 - Extension or group activities error.
           4 - Scratch file error.
         """
-        self._fvsGetICCode.argtypes = [ct.POINTER(ct.c_int)]
-        self._fvsGetICCode.restype = None
-        self._fvsGetICCode(self._exit_code)
-
-        return self._exit_code.value
+        return call_out(self._fvsGetICCode)
 
     @fvs_property
     def itrncd(self) -> int:
@@ -123,12 +100,7 @@ class FVS(FvsCore):
          2: indicates that FVS has finished processing all the stands; new input
                 can be specified.
         """
-        self._fvsGetRtnCode.argtypes = [ct.POINTER(ct.c_int)]
-        self._fvsGetRtnCode.restype = None
-
-        self._fvsGetRtnCode(self._itrncd)
-
-        return self._itrncd.value
+        return call_out(self._fvsGetRtnCode)
 
     @fvs_property
     def restart_code(self) -> int:
@@ -144,11 +116,7 @@ class FVS(FvsCore):
         100: Stop was done after a stand has been simulated but prior to
                 starting a subsequent stand.
         """
-        self._fvsGetRestartCode.argtypes = [ct.POINTER(ct.c_int)]
-        self._fvsGetRestartCode.restype = None
-        self._fvsGetRestartCode(self._restart_code)
-
-        return self._restart_code.value
+        return call_out(self._fvsGetRestartCode)
 
     @fvs_property
     def species(self) -> pd.DataFrame:
@@ -160,17 +128,6 @@ class FVS(FvsCore):
     @fvs_property
     def species_codes(self) -> pd.DataFrame:
         """Fetch the various codes used to refer to different tree species."""
-        self._fvsSpeciesCode.argtypes = [
-            ct.c_char_p,  # FVS species code
-            ct.c_char_p,  # FIA species code
-            ct.c_char_p,  # PLANTS code
-            ct.POINTER(ct.c_int),  # species index for this variant
-            ct.POINTER(ct.c_int),  # num char for fvs code
-            ct.POINTER(ct.c_int),  # num char for fia code
-            ct.POINTER(ct.c_int),  # num char for plants code
-            ct.POINTER(ct.c_int),  # return code
-        ]
-        self._fvsSpeciesCode.restype = None
         dims = self.dims
 
         _fvs_spp = ct.create_string_buffer(4)
@@ -256,16 +213,6 @@ class FVS(FvsCore):
     @fvs_property
     def stand_ids(self) -> dict:
         """Return stand identification codes."""
-        self._fvsStandID.argtypes = [
-            ct.c_char_p,  # stand id
-            ct.c_char_p,  # database control number
-            ct.c_char_p,  # management id
-            ct.POINTER(ct.c_int),  # length of stand id
-            ct.POINTER(ct.c_int),  # length of control number
-            ct.POINTER(ct.c_int),  # length of management id
-        ]
-        self._fvsStandID.restype = None
-
         if self.keyfile is None:
             msg = "Keyfile not loaded yet."
             raise AttributeError(msg)
@@ -376,13 +323,6 @@ class FVS(FvsCore):
             logging.debug("FVS was already started. Resetting.")
             self._reload_fvs()
 
-        self._fvsSetCmdLine.argtypes = [
-            ct.c_char_p,
-            ct.POINTER(ct.c_int),
-            ct.POINTER(ct.c_int),
-        ]
-        self._fvsSetCmdLine.restype = None
-
         self.keyfile_path = Path(os.path.abspath(keywordfile))
         with open(self.keyfile_path) as f:
             self.keyfile = f.read()
@@ -421,12 +361,6 @@ class FVS(FvsCore):
                -1 : Stop at every cycle
                YYYY : A specific year during the simulation period
         """
-        self._fvsSetStoppointCodes.argtypes = [
-            ct.POINTER(ct.c_int),
-            ct.POINTER(ct.c_int),
-        ]
-        self._fvsSetStoppointCodes.restype = None
-
         if stop_point_code is not None:
             if stop_point_code in range(-1, 8):
                 self._stop_point_code = ct.c_int(stop_point_code)  # type: ignore[assignment]
@@ -514,9 +448,6 @@ class FVS(FvsCore):
                -1 : Stop at every cycle
                YYYY : A specific year during the simulation period
         """
-        self._fvs.argtypes = [ct.POINTER(ct.c_int)]
-        self._fvs.restype = None
-
         if self.keyfile is None:
             msg = "No keyfile loaded yet."
             raise AttributeError(msg)

--- a/fvs2py/_core.py
+++ b/fvs2py/_core.py
@@ -5,6 +5,7 @@ import logging
 import os
 from pathlib import Path
 
+from fvs2py._signatures import FVS_SIGNATURES
 from fvs2py.common import load_dll, unload_dll
 from fvs2py.constants import NEEDED_ROUTINES
 
@@ -12,11 +13,21 @@ from fvs2py.constants import NEEDED_ROUTINES
 class FvsCore:
     """Base class for FVS API wrapper."""
 
-    def __init__(self, lib_path: str | os.PathLike):
-        """Loads FVS shared library and checks to ensure needed routines exist.
+    def __init__(self, lib_path: str | os.PathLike) -> None:
+        """Load the FVS shared library and bind its needed routines.
+
+        Resolves each routine in :data:`NEEDED_ROUTINES` from the loaded
+        library, tolerating both the unix-style ``name_`` mangling and the
+        un-mangled ``name`` spelling, then applies any static ctypes
+        signature declared in :data:`FVS_SIGNATURES` so call sites no longer
+        need to reassign ``argtypes``/``restype`` on each invocation.
 
         Args:
-          lib_path : path to FVS library
+            lib_path: Path to the FVS shared library.
+
+        Raises:
+            ImportError: If one or more routines in :data:`NEEDED_ROUTINES`
+                are not present or not callable on the loaded library.
         """
         self.lib_path: Path = Path(os.path.abspath(lib_path))
         self._lib: ct.CDLL | None = None
@@ -27,8 +38,8 @@ class FvsCore:
             .upper()
         )
 
-        # Declare function attributes with type annotations for mypy
-        # These are ctypes foreign function pointers loaded from the shared library
+        # Declare function attributes with type annotations for mypy.
+        # These are ctypes foreign function pointers loaded from the shared library.
         self._fvs: ct._FuncPointer
         self._fvsAddActivity: ct._FuncPointer
         self._fvsAddTrees: ct._FuncPointer
@@ -52,24 +63,40 @@ class FvsCore:
         self._load_fvs()
         assert self._lib is not None  # to satisfy type checker
 
-        # check for needed routines that are missing
-        missing = []
+        self._resolve_routines()
 
-        for routine in NEEDED_ROUTINES:
-            if hasattr(self._lib, routine) and callable(
-                getattr(self._lib, routine)
-            ):
-                logging.debug(f"Found {routine} as expected.")
-                # anticipate subroutine name changes depending upon compiler and OS
-                # unix pattern on fortran functions
-            elif hasattr(self._lib, f"{routine.lower()}_") and callable(
-                getattr(self._lib, f"{routine.lower()}_")
-            ):
-                logging.debug(f"Found {routine} renamed as {routine.lower()}_.")
-            else:
-                missing.append(routine)
+    def _resolve_routines(self) -> None:
+        """Bind each needed FVS routine to ``self`` and apply its signature.
 
-        if len(missing) > 0:
+        For every name in :data:`NEEDED_ROUTINES`, look up the corresponding
+        foreign function on ``self._lib`` (trying the ``name_`` mangling
+        first, then the un-mangled name), assign the resolved function to
+        ``self._<name>``, and apply any signature declared in
+        :data:`FVS_SIGNATURES`.
+
+        Raises:
+            ImportError: If any needed routines are missing or not callable.
+        """
+        assert self._lib is not None  # to satisfy type checker
+        missing: list[str] = []
+        for name in NEEDED_ROUTINES:
+            func: ct._FuncPointer | None = None
+            for candidate in (f"{name.lower()}_", name):
+                attr = getattr(self._lib, candidate, None)
+                if attr is not None and callable(attr):
+                    func = attr
+                    logging.debug(f"Found {name} as {candidate}.")
+                    break
+            if func is None:
+                missing.append(name)
+                continue
+            sig = FVS_SIGNATURES.get(name)
+            if sig is not None:
+                func.argtypes = sig.argtypes
+                func.restype = sig.restype
+            setattr(self, f"_{name}", func)
+
+        if missing:
             msg = " ".join(
                 [
                     ", ".join(missing),
@@ -78,60 +105,18 @@ class FvsCore:
                 ]
             )
             raise ImportError(msg)
-        try:
-            self._fvs = self._lib.fvs_
-            self._fvsAddActivity = self._lib.fvsaddactivity_
-            self._fvsAddTrees = self._lib.fvsaddtrees_
-            self._fvsDimSizes = self._lib.fvsdimsizes_
-            self._fvsEvmonAttr = self._lib.fvsevmonattr_
-            self._fvsFFEAttrs = self._lib.fvsffeattrs_
-            self._fvsGetRestartCode = self._lib.fvsgetrestartcode_
-            self._fvsGetRtnCode = self._lib.fvsgetrtncode_
-            self._fvsGetICCode = self._lib.fvsgeticcode_
-            self._fvsSVSDimSizes = self._lib.fvssvsdimsizes_
-            self._fvsSetStoppointCodes = self._lib.fvssetstoppointcodes_
-            self._fvsSetCmdLine = self._lib.fvssetcmdline_
-            self._fvsSVSObjData = self._lib.fvssvsobjdata_
-            self._fvsSpeciesAttr = self._lib.fvsspeciesattr_
-            self._fvsSpeciesCode = self._lib.fvsspeciescode_
-            self._fvsStandID = self._lib.fvsstandid_
-            self._fvsSummary = self._lib.fvssummary_
-            self._fvsTreeAttr = self._lib.fvstreeattr_
-            self._fvsUnitConversion = self._lib.fvsunitconversion_
-        except AttributeError:
-            self._fvs = self._lib.fvs
-            self._fvsAddActivity = self._lib.fvsAddActivity
-            self._fvsAddTrees = self._lib.fvsAddTrees
-            self._fvsDimSizes = self._lib.fvsDimSizes
-            self._fvsEvmonAttr = self._lib.fvsEvmonAttr
-            self._fvsFFEAttrs = self._lib.fvsFFEAttrs
-            self._fvsGetRestartCode = self._lib.fvsGetRestartCode
-            self._fvsGetRtnCode = self._lib.fvsGetRtnCode
-            self._fvsGetICCode = self._lib.fvsGetICCode
-            self._fvsSVSDimSizes = self._lib.fvsSVSDimSizes
-            self._fvsSetStoppointCodes = self._lib.fvsSetStoppointCodes
-            self._fvsSetCmdLine = self._lib.fvsSetCmdLine
-            self._fvsSVSObjData = self._lib.fvsSVSObjData
-            self._fvsSpeciesAttr = self._lib.fvsSpeciesAttr
-            self._fvsSpeciesCode = self._lib.fvsSpeciesCode
-            self._fvsStandID = self._lib.fvsStandID
-            self._fvsSummary = self._lib.fvsSummary
-            self._fvsTreeAttr = self._lib.fvsTreeAttr
-            self._fvsUnitConversion = self._lib.fvsUnitConversion
-
-        return
 
     def _load_fvs(self) -> None:
+        """Load the FVS shared library into ``self._lib``, unloading any prior handle."""
         if self._lib:
             logging.debug("Unloading existing library.")
             self._unload_fvs()
         self._lib = load_dll(self.lib_path)
-        return
 
     def _unload_fvs(self) -> None:
+        """Unload the currently held FVS shared library, if any."""
         if self._lib:
             unload_dll(self._lib)
             self._lib = None
         else:
             logging.debug("No library to unload.")
-        return

--- a/fvs2py/_signatures.py
+++ b/fvs2py/_signatures.py
@@ -1,0 +1,55 @@
+"""Declarative ctypes signatures for FVS routines.
+
+Holds a single source of truth mapping FVS routine names (as exposed by the
+shared library) to their ctypes ``argtypes``/``restype``. ``FvsCore`` consumes
+this during routine resolution and applies the signature to each resolved
+foreign function exactly once, eliminating per-call ``argtypes``/``restype``
+reassignment at call sites.
+
+Only routines with a static argument shape live here. Routines whose argument
+shapes depend on runtime dimensions (``fvsSummary``, ``fvsSpeciesAttr``,
+``fvsTreeAttr``) still set ``argtypes`` locally before calling, since the
+shapes cannot be decided at import time.
+"""
+
+from __future__ import annotations
+
+import ctypes as ct
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import NamedTuple
+
+
+class Signature(NamedTuple):
+    """Ctypes call signature for a single FVS routine.
+
+    Attributes:
+        argtypes: Tuple of ctypes types describing the routine's argument list
+            in declaration order.
+        restype: Ctypes return type, or ``None`` if the routine returns nothing.
+    """
+
+    argtypes: tuple[type, ...]
+    restype: type | None = None
+
+
+FVS_SIGNATURES: Mapping[str, Signature] = MappingProxyType(
+    {
+        "fvs": Signature((ct.POINTER(ct.c_int),)),
+        "fvsDimSizes": Signature((ct.POINTER(ct.c_int),) * 7),
+        "fvsGetICCode": Signature((ct.POINTER(ct.c_int),)),
+        "fvsGetRtnCode": Signature((ct.POINTER(ct.c_int),)),
+        "fvsGetRestartCode": Signature((ct.POINTER(ct.c_int),)),
+        "fvsSetStoppointCodes": Signature((ct.POINTER(ct.c_int),) * 2),
+        "fvsSetCmdLine": Signature(
+            (ct.c_char_p, ct.POINTER(ct.c_int), ct.POINTER(ct.c_int)),
+        ),
+        "fvsStandID": Signature(
+            (ct.c_char_p,) * 3 + (ct.POINTER(ct.c_int),) * 3,
+        ),
+        "fvsSpeciesCode": Signature(
+            (ct.c_char_p,) * 3 + (ct.POINTER(ct.c_int),) * 5,
+        ),
+    }
+)
+"""Immutable registry of static-shape FVS routine signatures."""

--- a/fvs2py/common.py
+++ b/fvs2py/common.py
@@ -5,7 +5,7 @@ import functools
 import logging
 import os
 from collections.abc import Callable
-from typing import ParamSpec, TypeVar, cast
+from typing import Any, ParamSpec, TypeVar, cast
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -105,3 +105,32 @@ def class_requires_fvs_library(cls: ClassT) -> ClassT:
             decorated_method = function_requires_fvs_library()(method)
             setattr(cls, name, decorated_method)
     return cls
+
+
+def call_out(
+    func: Callable[..., Any],
+    *in_args: Any,
+    out_types: tuple[type, ...] = (ct.c_int,),
+) -> Any:
+    """Call a ctypes function, auto-allocating output pointer args.
+
+    Allocates one fresh ctypes object of each type in ``out_types``, appends
+    them (in order) after ``in_args`` when calling ``func``, and returns the
+    unwrapped ``.value`` of each output.
+
+    Args:
+        func: Resolved ctypes foreign function whose trailing parameters are
+            ``POINTER`` types corresponding to ``out_types``.
+        *in_args: Positional input arguments passed to ``func`` unchanged.
+        out_types: Ctypes scalar types to allocate as output parameters.
+            Defaults to a single ``ct.c_int`` output.
+
+    Returns:
+        The scalar value if exactly one output was requested, otherwise a
+        tuple of unwrapped scalars in declaration order.
+    """
+    outs = [t(0) for t in out_types]
+    func(*in_args, *outs)
+    if len(outs) == 1:
+        return outs[0].value
+    return tuple(o.value for o in outs)

--- a/fvs2py/tests/test_fvs_build.py
+++ b/fvs2py/tests/test_fvs_build.py
@@ -42,7 +42,7 @@ def test_fvs_build(variant: FvsVariant, tmp_path: Path):
     with open(keyfile, "w") as f:
         f.write(keyfile_content)
     outfile = f"{tmp_path}/{variant}_buildtest.out"
-    proc = subprocess.run([fvs, f"--keywordfile={keyfile}"])
+    proc = subprocess.run([fvs, f"--keywordfile={keyfile}"], cwd=tmp_path)
 
     assert os.path.exists(keyfile)
     assert os.path.exists(outfile)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,8 +73,3 @@ convention = "google"
 [tool.mypy]
 mypy_path = "fvs2py"
 files = "fvs2py"
-
-[tool.pytest.ini_options]
-filterwarnings = [
-    "ignore:(?s).*Pyarrow will become a required dependency of pandas:DeprecationWarning", # pandas pyarrow (pandas<3.0),
-]


### PR DESCRIPTION
## Summary
Eliminates per-call `argtypes`/`restype` assignments and the brittle `try/except` block in `FvsCore.__init__`, without introducing new abstractions. Adds `call_out` helper to return python instead of ctypes objects that need value to be unpacked.

Minor changes added to pyproject.toml to remove unused sqlalchemy plugin, and to test_fvs_build so that subprocess is called within the temp folder to avoid pollution of repo by temporary FVS output files form testing.

## Changes
### New: `fvs2py/_signatures.py`
- A `Signature = NamedTuple(argtypes, restype)` plus a read-only `FVS_SIGNATURES: Mapping[str, Signature]` (backed by `MappingProxyType`) for the nine static-shape FVS routines (`fvs`, `fvsDimSizes`, `fvsGetICCode`, `fvsGetRtnCode`, `fvsGetRestartCode`, `fvsSetStoppointCodes`, `fvsSetCmdLine`, `fvsStandID`, `fvsSpeciesCode`).
- `fvsSummary`, `fvsSpeciesAttr`, and `fvsTreeAttr` intentionally stay out of the registry — their shapes depend on runtime dimensions and they continue to set `argtypes` locally at their call sites.
### `fvs2py/_core.py`
- Replaced the duplicated routine-existence loop + `try/except` platform-naming block (~90 lines) with a single `_resolve_routines()` method that:
  - Tries the `name_` mangling first, then the un-mangled `name`.
  - Retains the `callable()` check (so `test_routine_not_callable` still passes).
  - Applies `argtypes`/`restype` from `FVS_SIGNATURES` once, right after resolution.
  - Raises `ImportError` with the same message format as before for missing routines.
### `fvs2py/common.py`
- New `call_out(func, *in_args, out_types=(ct.c_int,))` helper: auto-allocates output pointer args, invokes the ctypes function, and returns the unwrapped `.value` (scalar for a single output, tuple for multiple).
### `fvs2py/_base.py`
- Converted `exit_code`, `itrncd`, `restart_code` from "allocate-buffer + assign argtypes + call + return .value" boilerplate to a single `call_out(...)` line each.
- Collapsed `dims` to `call_out(self._fvsDimSizes, out_types=(ct.c_int,) * 7)` + and returns a dict instead of saving to a private attribute.
- Removed the per-call `argtypes`/`restype` reassignments from `species_codes`, `stand_ids`, `load_keyfile`, `set_stop_point_codes`, and `run` — all now rely on the signature applied once by `FvsCore._resolve_routines`.
## Constraints preserved
- Every routine's `argtypes`/`restype` ends up set to the same values it had before; just set once per library load rather than on every call.
- Missing-routine and not-callable error messages are byte-for-byte identical to the prior implementation.
- `test_base.py` is untouched.

## Test plan
All unit tests continue passing. 