### PR TITLE
Refactor base FVS to be composed on mixins, breaking monolithic class into submodules

### DIFF
--- a/fvs2py/_base.py
+++ b/fvs2py/_base.py
@@ -1,48 +1,48 @@
-import ctypes as ct
-import logging
-import os
-import warnings
-from pathlib import Path
+"""Public :class:`FVS` class, assembled from focused mixins over :class:`FvsCore`."""
 
-import numpy as np
-import numpy.typing as npt
-import pandas as pd
+from __future__ import annotations
+
+import ctypes as ct
+import os
 
 from fvs2py._core import FvsCore
-from fvs2py.common import call_out, class_requires_fvs_library, fvs_property
-from fvs2py.constants import (
-    FVS_ITRNCD_FINISHED_ALL_STANDS,
-    FVS_ITRNCD_NOT_STARTED,
-    MGMT_ID_COLUMN_NAME,
-    SPECIES_ATTRS,
-    SPECIES_COLUMN_NAMES,
-    STAND_CN_COLUMN_NAME,
-    STAND_ID_COLUMN_NAME,
-    STR_C_CONTIGUOUS,
-    STR_MAXCYCLES,
-    STR_MAXPLOTS,
-    STR_MAXSPECIES,
-    STR_MAXTREES,
-    STR_NCYCLES,
-    STR_NPLOTS,
-    STR_NTREES,
-    SUMMARY_COLS,
+from fvs2py._mixins import (
+    ControlMixin,
+    SimulationMixin,
+    SpeciesMixin,
+    StandMixin,
 )
-from fvs2py.enums import FvsAttributeAccessor
+from fvs2py.common import class_requires_fvs_library
+from fvs2py.constants import SPECIES_ATTRS
 
 
 @class_requires_fvs_library
-class FVS(FvsCore):
-    """Main class for interacting with FVS at runtime."""
+class FVS(SpeciesMixin, StandMixin, SimulationMixin, ControlMixin, FvsCore):
+    """Main class for interacting with FVS at runtime.
 
-    def __init__(self, lib_path: str | os.PathLike):
+    Public behavior is contributed by the four mixins
+    (:class:`SpeciesMixin`, :class:`StandMixin`, :class:`SimulationMixin`,
+    :class:`ControlMixin`); this class just initializes the Python-side
+    buffers they rely on and wires the library-reload hook.
+    """
+
+    def __init__(self, lib_path: str | os.PathLike) -> None:
+        """Load the FVS shared library and initialize per-instance buffers.
+
+        Args:
+            lib_path: Path to the FVS shared library.
+        """
         super().__init__(lib_path=lib_path)
         self._initialize_attributes()
-        return
 
     def _initialize_attributes(self) -> None:
-        self.keyfile_path: Path | None = None
-        self.keyfile: str | None = None
+        """Reset all Python-side buffers and state tracked alongside FVS.
+
+        Called both at construction and after :meth:`_reload_fvs` so the
+        mixins can rely on a known set of pre-initialized attributes.
+        """
+        self.keyfile_path = None
+        self.keyfile = None
         self._exit_code = ct.c_int(0)
         self._itrncd = ct.c_int(-1)
         self._maxcycles = ct.c_int(0)
@@ -60,482 +60,8 @@ class FVS(FvsCore):
         self._stop_point_code = None
         self._stop_point_year = None
 
-    @fvs_property
-    def dims(self) -> dict:
-        """Return the max dimensions of important FVS data storage."""
-        ntrees, ncycles, nplots, maxtrees, maxspecies, maxplots, maxcycles = (
-            call_out(self._fvsDimSizes, out_types=(ct.c_int,) * 7)
-        )
-        return {
-            STR_NTREES: ntrees,
-            STR_NCYCLES: ncycles,
-            STR_NPLOTS: nplots,
-            STR_MAXTREES: maxtrees,
-            STR_MAXSPECIES: maxspecies,
-            STR_MAXPLOTS: maxplots,
-            STR_MAXCYCLES: maxcycles,
-        }
-
-    @fvs_property
-    def exit_code(self) -> int:
-        """Gets the integer code returned when FVS exits.
-
-        Possible values are:
-          0 - No serious errors occurred.
-          1 - Input data error.
-          2 - Keyword or expression error.
-          3 - Extension or group activities error.
-          4 - Scratch file error.
-        """
-        return call_out(self._fvsGetICCode)
-
-    @fvs_property
-    def itrncd(self) -> int:
-        """Returns with the current return code value in FVS.
-
-        -1: indicates that FVS has not been started.
-         0: indicates that FVS is in good running state.
-         1: indicates that FVS has detected an error of some kind and should not
-                be used until reset by specifying new input.
-         2: indicates that FVS has finished processing all the stands; new input
-                can be specified.
-        """
-        return call_out(self._fvsGetRtnCode)
-
-    @fvs_property
-    def restart_code(self) -> int:
-        """A code indicating when FVS stopped.
-
-          1: Stop was done just before the first call to the Event Monitor.
-          2: Stop was done just after the first call to the Event Monitor.
-          3: Stop was done just before the second call to the Event Monitor.
-          4: Stop was done just after the second call to the Event Monitor.
-          5: Stop was done after growth and mortality has been computed, but
-                prior to applying them.
-          6: Stop was done just before the ESTAB routines are called.
-        100: Stop was done after a stand has been simulated but prior to
-                starting a subsequent stand.
-        """
-        return call_out(self._fvsGetRestartCode)
-
-    @fvs_property
-    def species(self) -> pd.DataFrame:
-        """Returns species codes and attributes for all species."""
-        codes = self.species_codes
-        attrs = self.species_attrs
-        return codes.merge(attrs, left_index=True, right_index=True, copy=False)
-
-    @fvs_property
-    def species_codes(self) -> pd.DataFrame:
-        """Fetch the various codes used to refer to different tree species."""
-        dims = self.dims
-
-        _fvs_spp = ct.create_string_buffer(4)
-        _fia_spp = ct.create_string_buffer(4)
-        _plants_spp = ct.create_string_buffer(6)
-        returncd = ct.c_int(0)
-
-        spp_codes = pd.DataFrame(
-            index=range(dims[STR_MAXSPECIES]),
-            columns=SPECIES_COLUMN_NAMES,
-        )
-
-        for i in range(dims[STR_MAXSPECIES]):
-            self._fvsSpeciesCode(
-                _fvs_spp,
-                _fia_spp,
-                _plants_spp,
-                ct.c_int(i + 1),
-                ct.c_int(0),
-                ct.c_int(0),
-                ct.c_int(0),
-                ct.c_int(0),
-            )
-            if returncd.value != 0:
-                msg = f"Index {i + 1} out of range"
-                raise IndexError(msg)
-            spp_codes.iloc[i] = (
-                i + 1,
-                _fvs_spp.value.decode().strip(),
-                _fia_spp.value.decode().strip(),
-                _plants_spp.value.decode().strip(),
-            )
-
-        return spp_codes
-
-    @fvs_property
-    def species_attrs(self) -> pd.DataFrame:
-        """Returns a dataframe of species attributes.
-
-        Fields returned are:
-            spccf: CCF for each species, recomputed in FVS so setting will
-                likely have no effect
-            spsdi: SDI maximums for each species
-            spsiteindx: Species site indices
-            bfmind: Min diameter related to BFVOLUME keyword
-            bftopd: Top diameter related to BFVOLUME keyword
-            bfstmp: Stump height related to BFVOLUME keyword
-            frmcls: Form class related to BFVOLUME keyword
-            bfmeth: Volume calculation code related to BFVOLUME keyword
-                (internal FVS variable methb)
-            mcmind: Min diameter related to VOLUME keyword (internal FVS
-                variable dbhmin)
-            mctopd: Top diameter related to VOLUME keyword (internal FVS
-                variable topd)
-            mcstmp: Stump height related to VOLUME keyword (internal FVS
-                variable stmp)
-            mcmeth: Volume calculation code related to VOLUME keyword (internal
-                FVS variable methc)
-            baimult: Basal area increment multiplier for large trees (internal
-                FVS variable xdmult)
-            htgmult: Height growth multiplier for large trees (internal FVS
-                variable xhmult)
-            mortmult: Mortality rate multiplier (internal FVS variable xmmult)
-            mortdia1: Lower diameter limit for mortality multiplier (internal
-                FVS variable xmdia1)
-            mortdia2: Upper diameter limit for mortality multiplier (internal
-                FVS variable xmdia2)
-            regdmult: Diameter growth mulitplier for regeneration (internal FVS
-                variable xrdmlt)
-            reghmult: Height growth multiplier for regeneration (internal FVS
-                variable xrhmlt)
-        """
-        for attr in self._species_attrs:
-            _ = self.get_species_attr(attr)
-
-        attrs = pd.DataFrame(self._species_attrs, copy=False)
-        if (attrs == 0).all().all():
-            warnings.warn("No species attributes initialized yet.")
-            return attrs.replace(0, None)
-
-        return attrs
-
-    @fvs_property
-    def stand_ids(self) -> dict:
-        """Return stand identification codes."""
-        if self.keyfile is None:
-            msg = "Keyfile not loaded yet."
-            raise AttributeError(msg)
-        if self.stop_point_code is None:
-            msg = "No inventory data loaded yet. Call `run` method."
-            raise RuntimeError(msg)
-
-        self._fvsStandID(
-            self._stand_id,
-            self._stand_cn,
-            self._mgmt_id,
-            ct.c_int(0),
-            ct.c_int(0),
-            ct.c_int(0),
-        )
-
-        return {
-            STAND_ID_COLUMN_NAME: self._stand_id.value.decode().strip(),
-            STAND_CN_COLUMN_NAME: self._stand_cn.value.decode().strip(),
-            MGMT_ID_COLUMN_NAME: self._mgmt_id.value.decode().strip(),
-        }
-
-    @property
-    def stop_point_code(self) -> int | None:
-        """A code used to instruct FVS when to stop during a cycle.
-
-        -1 : Stop at every stop location.
-         0 : Never stop.
-         1 : Stop just before the first call to the Event Monitor.
-         2 : Stop just after the first call to the Event Monitor.
-         3 : Stop just before the second call to the Event Monitor.
-         4 : Stop just after the second call to the Event Monitor.
-         5 : Stop after growth and mortality has been computed, but prior to
-                applying them.
-         6 : Stop just before the ESTAB routines are called.
-         7 : Stop just after input is read but before missing values are imputed
-                (tree heights and crown ratios, for example) and model
-                calibration (argument stptyr is ignored).
-        """
-        if self._stop_point_code is not None:
-            return self._stop_point_code.value
-        return None
-
-    @property
-    def stop_point_year(self) -> int | None:
-        """A code indicating which cycles FVS should stop at.
-
-        0 : Never stop.
-        1 : Stop at every cycle.
-        YYYY : A specific year during the simulation period.
-        """
-        if self._stop_point_year is not None:
-            return self._stop_point_year.value
-        return None
-
-    @fvs_property
-    def summary(self) -> pd.DataFrame:
-        """Return a dataframe with FVS Summary Statistics for all initiated cycles.
-
-        The returned dataframe omits cycles that have not yet been initiated, which are
-        identifiable where all values in that row are zero.
-        """
-        self._fvsSummary.argtypes = [
-            np.ctypeslib.ndpointer(np.intc, flags=STR_C_CONTIGUOUS),
-            ct.POINTER(ct.c_int),
-            ct.POINTER(ct.c_int),
-            ct.POINTER(ct.c_int),
-            ct.POINTER(ct.c_int),
-            ct.POINTER(ct.c_int),
-        ]
-        self._fvsSummary.restype = None
-
-        dims = self.dims
-        if dims[STR_NCYCLES] == 0:
-            return None
-        summary = np.zeros(
-            dtype=np.intc,
-            shape=(dims[STR_NCYCLES] + 1, len(SUMMARY_COLS)),
-        )
-        for i in range(dims[STR_NCYCLES] + 1):
-            self._fvsSummary(
-                summary[i],
-                ct.c_int(i + 1),  # icycle
-                ct.c_int(dims[STR_NCYCLES]),  # ncycles
-                ct.c_int(0),  # maxrow
-                ct.c_int(0),  # maxcol
-                ct.c_int(0),  # rtncode
-            )
-
-        empty_years = (summary == 0).all(axis=1)
-        return pd.DataFrame(
-            summary[~empty_years, :], columns=SUMMARY_COLS
-        ).copy()
-
-    def load_keyfile(self, keywordfile: str | os.PathLike) -> None:
-        """Sets the keywordfile as a command line argument to FVS.
-
-        Args:
-          keywordfile (str | os.PathLike): path to the FVS keyword file
-        """
-        if self.itrncd != FVS_ITRNCD_NOT_STARTED:
-            if self.itrncd != FVS_ITRNCD_FINISHED_ALL_STANDS:
-                msg = (
-                    "FVS had not completed the previous simulation. "
-                    "Outputs from that simulation may be incomplete."
-                )
-                warnings.warn(msg)
-            logging.debug("FVS was already started. Resetting.")
-            self._reload_fvs()
-
-        self.keyfile_path = Path(os.path.abspath(keywordfile))
-        with open(self.keyfile_path) as f:
-            self.keyfile = f.read()
-
-        cmdline = f"--keywordfile={self.keyfile_path}"
-        nch = len(cmdline)
-
-        self._fvsSetCmdLine(cmdline.encode(), ct.c_int(nch), self._itrncd)
-        logging.debug(f"Return code updated to {self.itrncd}")
-
-        return
-
-    def set_stop_point_codes(
-        self,
-        stop_point_code: int | None = None,
-        stop_point_year: int | None = None,
-    ) -> None:
-        """Sets FVS stop point codes.
-
-        Args:
-            stop_point_code (int): Optional code for when FVS should stop during
-                a cycle:
-               -1 : Stop at every stop location
-                0 : Never stop
-                1 : Stop just before the first call to the Event Monitor
-                2 : Stop just after the first call to the Event Monitor
-                3 : Stop just before the second call to the Event Monitor
-                4 : Stop just after the second call to the Event Monitor
-                5 : Stop after growth and mortality has been computed, but
-                        prior to applying them
-                6 : Stop just before the ESTAB routines are called
-                7 : Stop just after input is read but before missing values
-                        are imputed
-            stop_point_year (int): Optional, years FVS should stop, options are:
-                0 : Never stop
-               -1 : Stop at every cycle
-               YYYY : A specific year during the simulation period
-        """
-        if stop_point_code is not None:
-            if stop_point_code in range(-1, 8):
-                self._stop_point_code = ct.c_int(stop_point_code)  # type: ignore[assignment]
-            else:
-                msg = "Invalid value for stop_point_code"
-                raise ValueError(msg)
-        elif self._stop_point_code is None:
-            self._stop_point_code = ct.c_int(0)  # type: ignore[assignment]
-
-        if stop_point_year is not None:
-            if stop_point_code is not None:
-                self._stop_point_year = ct.c_int(stop_point_year)  # type: ignore[assignment]
-            else:
-                msg = (
-                    "Must specify stop_point_year if also specifying "
-                    "stop_point_code"
-                )
-                raise ValueError(msg)
-        elif self._stop_point_year is None:
-            self._stop_point_year = ct.c_int(0)  # type: ignore[assignment]
-
-        self._fvsSetStoppointCodes(self._stop_point_code, self._stop_point_year)
-
-        return
-
-    def get_species_attr(self, attr: str) -> npt.NDArray[np.float64]:
-        """Gets a single attribute for all existing species.
-
-        Args:
-            attr (str): name of species attribute to fetch
-
-        Returns:
-            array with values of requested attribute for all trees
-
-        """
-        self._species_attr(attr, FvsAttributeAccessor.GET)
-        return self._species_attrs[attr]
-
-    def set_species_attr(self, attr: str, arr: npt.NDArray[np.float64]) -> None:
-        """Sets a single attribute for all existing species.
-
-        Args:
-            attr (str): name of species attribute to fetch
-            arr (npt.NDArray[np.float64]): array of values to set
-
-        """
-        return self._species_attr(attr, FvsAttributeAccessor.SET, arr)
-
-    def run(
-        self,
-        stop_point_code: int = 0,
-        stop_point_year: int = 0,
-    ) -> None:
-        """Runs FVS.
-
-        Note that stopping after the simulation of each stand in a simulation is
-        done even when no stop request has been scheduled (that is, FVS will
-        return at the end of each stand in a simulation even if there are no
-        stop codes specified). Once a stand has been fully processed by FVS, the
-        FVS `restart_code` is set to 100 and the call to run() returns.
-
-        If there are multiple stands in a single keyfile, the simulation of the
-        next stand can be triggered by calling run() again.
-
-        The main output text file may be truncated even after the last stand has
-        been simulated. To conclude FVS writing to the main output file, call
-        run() one last time. The `itrncd` attribute should then change to a
-        value of 2, indicating all stands have been processed.
-
-        Args:
-            stop_point_code (optional, int): when FVS should stop during a cycle:
-               -1 : Stop at every stop location
-                0 : Never stop
-                1 : Stop just before the first call to the Event Monitor
-                2 : Stop just after the first call to the Event Monitor
-                3 : Stop just before the second call to the Event Monitor
-                4 : Stop just after the second call to the Event Monitor
-                5 : Stop after growth and mortality has been computed, but
-                        prior to applying them
-                6 : Stop just before the ESTAB routines are called
-                7 : Stop just after input is read but before missing values
-                        are imputed
-            stop_point_year (optional, int): years FVS should stop, options are:
-                0 : Never stop
-               -1 : Stop at every cycle
-               YYYY : A specific year during the simulation period
-        """
-        if self.keyfile is None:
-            msg = "No keyfile loaded yet."
-            raise AttributeError(msg)
-        logging.debug("Found keyfile.")
-        self.set_stop_point_codes(stop_point_code, stop_point_year)
-        logging.debug(
-            f"Set stop point codes, {stop_point_code}:{self.stop_point_code}, {stop_point_year}:{self.stop_point_year}"
-        )
-        while self.itrncd == 0:
-            logging.debug("itrncd still zero.")
-            self._fvs(self._itrncd)
-            logging.debug(f"Ran _fvs routine, itrncd is {self.itrncd}")
-            if self.restart_code != 0:
-                logging.debug("restart code not zero... halting run.")
-                break
-
-        return
-
-    def _species_attr(
-        self,
-        attr: str,
-        action: FvsAttributeAccessor,
-        arr: npt.NDArray[np.float64] | None = None,
-    ) -> None:
-        """Gets or sets a single attribute for all existing species.
-
-        Args:
-            attr (str): name of species attribute to get or set
-            action (FvsAttributeAccessor): 'get' or 'set'
-            arr (optional, npt.NDArray[np.float64]): array of values to set
-        """
-        if attr not in self._species_attrs:
-            msg = "Invalid variable requested. Valid options are"
-            raise NameError(msg, self._species_attrs)
-
-        dims = self.dims
-        if (
-            action == FvsAttributeAccessor.GET
-            and self._species_attrs[attr] is None
-        ):
-            self._species_attrs[attr] = np.empty(
-                dtype=np.float64, shape=(dims[STR_MAXSPECIES])
-            )
-        elif action == FvsAttributeAccessor.SET:
-            if arr is None:
-                msg = "Must provide `arr` if `action` is 'set'"
-                raise TypeError(msg)
-            if arr.shape != (dims[STR_MAXSPECIES],):
-                msg = (
-                    "`arr` must be same shape as `maxspecies` "
-                    f"({dims[STR_MAXSPECIES]},)"
-                )
-                raise ValueError(msg)
-            self._species_attrs[attr] = arr
-
-        self._fvsSpeciesAttr.argtypes = [
-            ct.POINTER(ct.c_char),  # attr name
-            ct.POINTER(ct.c_int),  # number of characters in attr name
-            ct.POINTER(ct.c_char),  # action (set or get)
-            np.ctypeslib.ndpointer(
-                np.float64, shape=(dims[STR_MAXSPECIES]), flags=STR_C_CONTIGUOUS
-            ),  # array to fill
-            ct.POINTER(ct.c_int),  # return code
-        ]
-        self._fvsSpeciesAttr.restype = None
-
-        rtncode = ct.c_int(0)
-        self._fvsSpeciesAttr(
-            ct.c_char_p(attr.encode()),  # attribute requested
-            ct.c_int(len(attr)),  # number of characters in attr name
-            ct.c_char_p(action.encode()),  # "set" or "get"
-            self._species_attrs[attr],  # array to fill
-            rtncode,  # return code of setting/getting operation
-        )
-        ERRS = {
-            0: "OK",
-            1: "name not found",
-            4: "length of name string was too large or small",
-        }
-
-        if rtncode.value != 0:
-            if rtncode.value == 1:
-                msg = f"{attr} not found among species attributes"
-                raise NameError(msg)
-            raise RuntimeError(ERRS[rtncode.value])
-
     def _reload_fvs(self) -> None:
+        """Unload the current library, load a fresh one, and reset buffers."""
         self._unload_fvs()
         self._load_fvs()
         self._initialize_attributes()
-        return

--- a/fvs2py/_mixins/__init__.py
+++ b/fvs2py/_mixins/__init__.py
@@ -1,0 +1,19 @@
+"""Focused mixins that compose the :class:`fvs2py.FVS` public API.
+
+Each mixin owns a coherent slice of FVS functionality and assumes the instance
+already has ``self._lib`` plus the resolved ``_fvsXyz`` foreign-function
+attributes from :class:`fvs2py._core.FvsCore` and the Python-side buffers
+initialized by ``FVS._initialize_attributes``.
+"""
+
+from fvs2py._mixins.control import ControlMixin
+from fvs2py._mixins.simulation import SimulationMixin
+from fvs2py._mixins.species import SpeciesMixin
+from fvs2py._mixins.stand import StandMixin
+
+__all__ = [
+    "ControlMixin",
+    "SimulationMixin",
+    "SpeciesMixin",
+    "StandMixin",
+]

--- a/fvs2py/_mixins/control.py
+++ b/fvs2py/_mixins/control.py
@@ -1,0 +1,149 @@
+"""Keyfile-loading and stop-point control mixin."""
+
+from __future__ import annotations
+
+import ctypes as ct
+import logging
+import os
+import warnings
+from collections.abc import Callable
+from pathlib import Path
+
+from fvs2py.constants import (
+    FVS_ITRNCD_FINISHED_ALL_STANDS,
+    FVS_ITRNCD_NOT_STARTED,
+)
+
+
+class ControlMixin:
+    """Expose keyfile loading and stop-point configuration.
+
+    Assumes the composed class provides ``_fvsSetCmdLine`` and
+    ``_fvsSetStoppointCodes`` (resolved by :class:`fvs2py._core.FvsCore`),
+    the ``_itrncd`` buffer, and the ``_stop_point_code``/``_stop_point_year``
+    slots initialized by ``FVS._initialize_attributes``. :meth:`run` on
+    :class:`SimulationMixin` is expected to call into
+    :meth:`set_stop_point_codes`.
+    """
+
+    _fvsSetCmdLine: ct._FuncPointer
+    _fvsSetStoppointCodes: ct._FuncPointer
+    _itrncd: ct.c_int
+    _stop_point_code: ct.c_int | None
+    _stop_point_year: ct.c_int | None
+    keyfile_path: Path | None
+    keyfile: str | None
+    itrncd: int
+    _reload_fvs: Callable[[], None]
+
+    @property
+    def stop_point_code(self) -> int | None:
+        """A code used to instruct FVS when to stop during a cycle.
+
+        -1 : Stop at every stop location.
+         0 : Never stop.
+         1 : Stop just before the first call to the Event Monitor.
+         2 : Stop just after the first call to the Event Monitor.
+         3 : Stop just before the second call to the Event Monitor.
+         4 : Stop just after the second call to the Event Monitor.
+         5 : Stop after growth and mortality has been computed, but prior to
+                applying them.
+         6 : Stop just before the ESTAB routines are called.
+         7 : Stop just after input is read but before missing values are imputed
+                (tree heights and crown ratios, for example) and model
+                calibration (argument stptyr is ignored).
+        """
+        if self._stop_point_code is not None:
+            return self._stop_point_code.value
+        return None
+
+    @property
+    def stop_point_year(self) -> int | None:
+        """A code indicating which cycles FVS should stop at.
+
+        0 : Never stop.
+        1 : Stop at every cycle.
+        YYYY : A specific year during the simulation period.
+        """
+        if self._stop_point_year is not None:
+            return self._stop_point_year.value
+        return None
+
+    def load_keyfile(self, keywordfile: str | os.PathLike) -> None:
+        """Sets the keywordfile as a command line argument to FVS.
+
+        Args:
+          keywordfile (str | os.PathLike): path to the FVS keyword file
+        """
+        if self.itrncd != FVS_ITRNCD_NOT_STARTED:
+            if self.itrncd != FVS_ITRNCD_FINISHED_ALL_STANDS:
+                msg = (
+                    "FVS had not completed the previous simulation. "
+                    "Outputs from that simulation may be incomplete."
+                )
+                warnings.warn(msg)
+            logging.debug("FVS was already started. Resetting.")
+            self._reload_fvs()
+
+        self.keyfile_path = Path(os.path.abspath(keywordfile))
+        with open(self.keyfile_path) as f:
+            self.keyfile = f.read()
+
+        cmdline = f"--keywordfile={self.keyfile_path}"
+        nch = len(cmdline)
+
+        self._fvsSetCmdLine(cmdline.encode(), ct.c_int(nch), self._itrncd)
+        logging.debug(f"Return code updated to {self.itrncd}")
+
+    def set_stop_point_codes(
+        self,
+        stop_point_code: int | None = None,
+        stop_point_year: int | None = None,
+    ) -> None:
+        """Sets FVS stop point codes.
+
+        Args:
+            stop_point_code (int): Optional code for when FVS should stop during
+                a cycle:
+               -1 : Stop at every stop location
+                0 : Never stop
+                1 : Stop just before the first call to the Event Monitor
+                2 : Stop just after the first call to the Event Monitor
+                3 : Stop just before the second call to the Event Monitor
+                4 : Stop just after the second call to the Event Monitor
+                5 : Stop after growth and mortality has been computed, but
+                        prior to applying them
+                6 : Stop just before the ESTAB routines are called
+                7 : Stop just after input is read but before missing values
+                        are imputed
+            stop_point_year (int): Optional, years FVS should stop, options are:
+                0 : Never stop
+               -1 : Stop at every cycle
+               YYYY : A specific year during the simulation period
+
+        Raises:
+            ValueError: If ``stop_point_code`` is outside the range ``[-1, 7]``,
+                or if ``stop_point_year`` is provided without ``stop_point_code``.
+        """
+        if stop_point_code is not None:
+            if stop_point_code in range(-1, 8):
+                self._stop_point_code = ct.c_int(stop_point_code)
+            else:
+                msg = "Invalid value for stop_point_code"
+                raise ValueError(msg)
+        elif self._stop_point_code is None:
+            self._stop_point_code = ct.c_int(0)
+
+        if stop_point_year is not None:
+            if stop_point_code is not None:
+                self._stop_point_year = ct.c_int(stop_point_year)
+            else:
+                msg = (
+                    "Must specify stop_point_year if also specifying "
+                    "stop_point_code"
+                )
+                raise ValueError(msg)
+        elif self._stop_point_year is None:
+            self._stop_point_year = ct.c_int(0)
+
+        self._fvsSetStoppointCodes(self._stop_point_code, self._stop_point_year)

--- a/fvs2py/_mixins/simulation.py
+++ b/fvs2py/_mixins/simulation.py
@@ -1,0 +1,130 @@
+"""Simulation lifecycle and run-status mixin."""
+
+from __future__ import annotations
+
+import ctypes as ct
+import logging
+from collections.abc import Callable
+
+from fvs2py.common import call_out, fvs_property
+
+
+class SimulationMixin:
+    """Expose FVS simulation status codes and the top-level :meth:`run` loop.
+
+    Assumes the composed class provides the foreign-function attributes
+    ``_fvs``, ``_fvsGetICCode``, ``_fvsGetRtnCode``, ``_fvsGetRestartCode``
+    (resolved by :class:`fvs2py._core.FvsCore`) plus the Python-side buffers
+    ``_itrncd``, ``keyfile``, and the :meth:`set_stop_point_codes` helper
+    contributed by :class:`ControlMixin`.
+    """
+
+    _fvs: ct._FuncPointer
+    _fvsGetICCode: ct._FuncPointer
+    _fvsGetRtnCode: ct._FuncPointer
+    _fvsGetRestartCode: ct._FuncPointer
+    _itrncd: ct.c_int
+    keyfile: str | None
+    stop_point_code: int | None
+    stop_point_year: int | None
+    set_stop_point_codes: Callable[..., None]
+
+    @fvs_property
+    def exit_code(self) -> int:
+        """Gets the integer code returned when FVS exits.
+
+        Possible values are:
+          0 - No serious errors occurred.
+          1 - Input data error.
+          2 - Keyword or expression error.
+          3 - Extension or group activities error.
+          4 - Scratch file error.
+        """
+        return call_out(self._fvsGetICCode)
+
+    @fvs_property
+    def itrncd(self) -> int:
+        """Returns with the current return code value in FVS.
+
+        -1: indicates that FVS has not been started.
+         0: indicates that FVS is in good running state.
+         1: indicates that FVS has detected an error of some kind and should not
+                be used until reset by specifying new input.
+         2: indicates that FVS has finished processing all the stands; new input
+                can be specified.
+        """
+        return call_out(self._fvsGetRtnCode)
+
+    @fvs_property
+    def restart_code(self) -> int:
+        """A code indicating when FVS stopped.
+
+          1: Stop was done just before the first call to the Event Monitor.
+          2: Stop was done just after the first call to the Event Monitor.
+          3: Stop was done just before the second call to the Event Monitor.
+          4: Stop was done just after the second call to the Event Monitor.
+          5: Stop was done after growth and mortality has been computed, but
+                prior to applying them.
+          6: Stop was done just before the ESTAB routines are called.
+        100: Stop was done after a stand has been simulated but prior to
+                starting a subsequent stand.
+        """
+        return call_out(self._fvsGetRestartCode)
+
+    def run(
+        self,
+        stop_point_code: int = 0,
+        stop_point_year: int = 0,
+    ) -> None:
+        """Runs FVS.
+
+        Note that stopping after the simulation of each stand in a simulation is
+        done even when no stop request has been scheduled (that is, FVS will
+        return at the end of each stand in a simulation even if there are no
+        stop codes specified). Once a stand has been fully processed by FVS, the
+        FVS `restart_code` is set to 100 and the call to run() returns.
+
+        If there are multiple stands in a single keyfile, the simulation of the
+        next stand can be triggered by calling run() again.
+
+        The main output text file may be truncated even after the last stand has
+        been simulated. To conclude FVS writing to the main output file, call
+        run() one last time. The `itrncd` attribute should then change to a
+        value of 2, indicating all stands have been processed.
+
+        Args:
+            stop_point_code (optional, int): when FVS should stop during a cycle:
+               -1 : Stop at every stop location
+                0 : Never stop
+                1 : Stop just before the first call to the Event Monitor
+                2 : Stop just after the first call to the Event Monitor
+                3 : Stop just before the second call to the Event Monitor
+                4 : Stop just after the second call to the Event Monitor
+                5 : Stop after growth and mortality has been computed, but
+                        prior to applying them
+                6 : Stop just before the ESTAB routines are called
+                7 : Stop just after input is read but before missing values
+                        are imputed
+            stop_point_year (optional, int): years FVS should stop, options are:
+                0 : Never stop
+               -1 : Stop at every cycle
+               YYYY : A specific year during the simulation period
+
+        Raises:
+            AttributeError: If no keyfile has been loaded yet.
+        """
+        if self.keyfile is None:
+            msg = "No keyfile loaded yet."
+            raise AttributeError(msg)
+        logging.debug("Found keyfile.")
+        self.set_stop_point_codes(stop_point_code, stop_point_year)
+        logging.debug(
+            f"Set stop point codes, {stop_point_code}:{self.stop_point_code}, {stop_point_year}:{self.stop_point_year}"
+        )
+        while self.itrncd == 0:
+            logging.debug("itrncd still zero.")
+            self._fvs(self._itrncd)
+            logging.debug(f"Ran _fvs routine, itrncd is {self.itrncd}")
+            if self.restart_code != 0:
+                logging.debug("restart code not zero... halting run.")
+                break

--- a/fvs2py/_mixins/species.py
+++ b/fvs2py/_mixins/species.py
@@ -1,0 +1,217 @@
+"""Species codes and per-species attribute access mixin."""
+
+from __future__ import annotations
+
+import ctypes as ct
+import warnings
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd  # type: ignore[import-untyped]
+
+from fvs2py.common import fvs_property
+from fvs2py.constants import (
+    SPECIES_COLUMN_NAMES,
+    STR_C_CONTIGUOUS,
+    STR_MAXSPECIES,
+)
+from fvs2py.enums import FvsAttributeAccessor
+
+
+class SpeciesMixin:
+    """Expose species metadata and per-species attribute get/set helpers.
+
+    Assumes the composed class provides the foreign-function attributes
+    ``_fvsSpeciesCode`` and ``_fvsSpeciesAttr`` (resolved by
+    :class:`fvs2py._core.FvsCore`) and the ``_species_attrs`` mapping
+    seeded by ``FVS._initialize_attributes``. Uses ``self.dims`` from
+    :class:`StandMixin`.
+    """
+
+    _fvsSpeciesCode: ct._FuncPointer
+    _fvsSpeciesAttr: ct._FuncPointer
+    _species_attrs: dict[str, npt.NDArray[np.float64] | None]
+    dims: dict
+
+    @fvs_property
+    def species(self) -> pd.DataFrame:
+        """Returns species codes and attributes for all species."""
+        codes = self.species_codes
+        attrs = self.species_attrs
+        return codes.merge(attrs, left_index=True, right_index=True, copy=False)
+
+    @fvs_property
+    def species_codes(self) -> pd.DataFrame:
+        """Fetch the various codes used to refer to different tree species."""
+        dims = self.dims
+
+        _fvs_spp = ct.create_string_buffer(4)
+        _fia_spp = ct.create_string_buffer(4)
+        _plants_spp = ct.create_string_buffer(6)
+        returncd = ct.c_int(0)
+
+        spp_codes = pd.DataFrame(
+            index=range(dims[STR_MAXSPECIES]),
+            columns=SPECIES_COLUMN_NAMES,
+        )
+
+        for i in range(dims[STR_MAXSPECIES]):
+            self._fvsSpeciesCode(
+                _fvs_spp,
+                _fia_spp,
+                _plants_spp,
+                ct.c_int(i + 1),
+                ct.c_int(0),
+                ct.c_int(0),
+                ct.c_int(0),
+                ct.c_int(0),
+            )
+            if returncd.value != 0:
+                msg = f"Index {i + 1} out of range"
+                raise IndexError(msg)
+            spp_codes.iloc[i] = (
+                i + 1,
+                _fvs_spp.value.decode().strip(),
+                _fia_spp.value.decode().strip(),
+                _plants_spp.value.decode().strip(),
+            )
+
+        return spp_codes
+
+    @fvs_property
+    def species_attrs(self) -> pd.DataFrame:
+        """Returns a dataframe of species attributes.
+
+        Fields returned are:
+            spccf: CCF for each species, recomputed in FVS so setting will
+                likely have no effect
+            spsdi: SDI maximums for each species
+            spsiteindx: Species site indices
+            bfmind: Min diameter related to BFVOLUME keyword
+            bftopd: Top diameter related to BFVOLUME keyword
+            bfstmp: Stump height related to BFVOLUME keyword
+            frmcls: Form class related to BFVOLUME keyword
+            bfmeth: Volume calculation code related to BFVOLUME keyword
+                (internal FVS variable methb)
+            mcmind: Min diameter related to VOLUME keyword (internal FVS
+                variable dbhmin)
+            mctopd: Top diameter related to VOLUME keyword (internal FVS
+                variable topd)
+            mcstmp: Stump height related to VOLUME keyword (internal FVS
+                variable stmp)
+            mcmeth: Volume calculation code related to VOLUME keyword (internal
+                FVS variable methc)
+            baimult: Basal area increment multiplier for large trees (internal
+                FVS variable xdmult)
+            htgmult: Height growth multiplier for large trees (internal FVS
+                variable xhmult)
+            mortmult: Mortality rate multiplier (internal FVS variable xmmult)
+            mortdia1: Lower diameter limit for mortality multiplier (internal
+                FVS variable xmdia1)
+            mortdia2: Upper diameter limit for mortality multiplier (internal
+                FVS variable xmdia2)
+            regdmult: Diameter growth mulitplier for regeneration (internal FVS
+                variable xrdmlt)
+            reghmult: Height growth multiplier for regeneration (internal FVS
+                variable xrhmlt)
+        """
+        for attr in self._species_attrs:
+            _ = self.get_species_attr(attr)
+
+        attrs = pd.DataFrame(self._species_attrs, copy=False)
+        if (attrs == 0).all().all():
+            warnings.warn("No species attributes initialized yet.")
+            return attrs.replace(0, None)
+
+        return attrs
+
+    def get_species_attr(self, attr: str) -> npt.NDArray[np.float64]:
+        """Gets a single attribute for all existing species.
+
+        Args:
+            attr (str): name of species attribute to fetch
+
+        Returns:
+            array with values of requested attribute for all trees
+
+        """
+        self._species_attr(attr, FvsAttributeAccessor.GET)
+        return self._species_attrs[attr]
+
+    def set_species_attr(self, attr: str, arr: npt.NDArray[np.float64]) -> None:
+        """Sets a single attribute for all existing species.
+
+        Args:
+            attr (str): name of species attribute to fetch
+            arr (npt.NDArray[np.float64]): array of values to set
+
+        """
+        return self._species_attr(attr, FvsAttributeAccessor.SET, arr)
+
+    def _species_attr(
+        self,
+        attr: str,
+        action: FvsAttributeAccessor,
+        arr: npt.NDArray[np.float64] | None = None,
+    ) -> None:
+        """Gets or sets a single attribute for all existing species.
+
+        Args:
+            attr (str): name of species attribute to get or set
+            action (FvsAttributeAccessor): 'get' or 'set'
+            arr (optional, npt.NDArray[np.float64]): array of values to set
+        """
+        if attr not in self._species_attrs:
+            msg = "Invalid variable requested. Valid options are"
+            raise NameError(msg, self._species_attrs)
+
+        dims = self.dims
+        if (
+            action == FvsAttributeAccessor.GET
+            and self._species_attrs[attr] is None
+        ):
+            self._species_attrs[attr] = np.empty(
+                dtype=np.float64, shape=(dims[STR_MAXSPECIES])
+            )
+        elif action == FvsAttributeAccessor.SET:
+            if arr is None:
+                msg = "Must provide `arr` if `action` is 'set'"
+                raise TypeError(msg)
+            if arr.shape != (dims[STR_MAXSPECIES],):
+                msg = (
+                    "`arr` must be same shape as `maxspecies` "
+                    f"({dims[STR_MAXSPECIES]},)"
+                )
+                raise ValueError(msg)
+            self._species_attrs[attr] = arr
+
+        self._fvsSpeciesAttr.argtypes = [
+            ct.POINTER(ct.c_char),  # attr name
+            ct.POINTER(ct.c_int),  # number of characters in attr name
+            ct.POINTER(ct.c_char),  # action (set or get)
+            np.ctypeslib.ndpointer(  # type: ignore[arg-type]
+                np.float64, shape=(dims[STR_MAXSPECIES]), flags=STR_C_CONTIGUOUS
+            ),  # array to fill
+            ct.POINTER(ct.c_int),  # return code
+        ]
+        self._fvsSpeciesAttr.restype = None
+
+        rtncode = ct.c_int(0)
+        self._fvsSpeciesAttr(
+            ct.c_char_p(attr.encode()),  # attribute requested
+            ct.c_int(len(attr)),  # number of characters in attr name
+            ct.c_char_p(action.encode()),  # "set" or "get"
+            self._species_attrs[attr],  # array to fill
+            rtncode,  # return code of setting/getting operation
+        )
+        ERRS = {
+            0: "OK",
+            1: "name not found",
+            4: "length of name string was too large or small",
+        }
+
+        if rtncode.value != 0:
+            if rtncode.value == 1:
+                msg = f"{attr} not found among species attributes"
+                raise NameError(msg)
+            raise RuntimeError(ERRS[rtncode.value])

--- a/fvs2py/_mixins/stand.py
+++ b/fvs2py/_mixins/stand.py
@@ -1,0 +1,131 @@
+"""Stand identification, dimensions, and summary mixin."""
+
+from __future__ import annotations
+
+import ctypes as ct
+
+import numpy as np
+import pandas as pd  # type: ignore[import-untyped]
+
+from fvs2py.common import call_out, fvs_property
+from fvs2py.constants import (
+    MGMT_ID_COLUMN_NAME,
+    STAND_CN_COLUMN_NAME,
+    STAND_ID_COLUMN_NAME,
+    STR_C_CONTIGUOUS,
+    STR_MAXCYCLES,
+    STR_MAXPLOTS,
+    STR_MAXSPECIES,
+    STR_MAXTREES,
+    STR_NCYCLES,
+    STR_NPLOTS,
+    STR_NTREES,
+    SUMMARY_COLS,
+)
+
+
+class StandMixin:
+    """Expose stand-level FVS outputs: dimensions, identifiers, summary table.
+
+    Assumes the composed class provides the foreign-function attributes
+    ``_fvsDimSizes``, ``_fvsStandID``, ``_fvsSummary`` (resolved by
+    :class:`fvs2py._core.FvsCore`) and the Python-side buffers ``_stand_id``,
+    ``_stand_cn``, ``_mgmt_id`` (initialized by
+    ``FVS._initialize_attributes``). ``keyfile`` and ``stop_point_code``
+    come from :class:`ControlMixin`.
+    """
+
+    _fvsDimSizes: ct._FuncPointer
+    _fvsStandID: ct._FuncPointer
+    _fvsSummary: ct._FuncPointer
+    _stand_id: ct.Array[ct.c_char]
+    _stand_cn: ct.Array[ct.c_char]
+    _mgmt_id: ct.Array[ct.c_char]
+    keyfile: str | None
+    stop_point_code: int | None
+
+    @fvs_property
+    def dims(self) -> dict:
+        """Return the max dimensions of important FVS data storage."""
+        ntrees, ncycles, nplots, maxtrees, maxspecies, maxplots, maxcycles = (
+            call_out(self._fvsDimSizes, out_types=(ct.c_int,) * 7)
+        )
+        return {
+            STR_NTREES: ntrees,
+            STR_NCYCLES: ncycles,
+            STR_NPLOTS: nplots,
+            STR_MAXTREES: maxtrees,
+            STR_MAXSPECIES: maxspecies,
+            STR_MAXPLOTS: maxplots,
+            STR_MAXCYCLES: maxcycles,
+        }
+
+    @fvs_property
+    def stand_ids(self) -> dict:
+        """Return stand identification codes.
+
+        Raises:
+            AttributeError: If no keyfile has been loaded.
+            RuntimeError: If inventory data has not yet been loaded (i.e.
+                :meth:`run` has not been called).
+        """
+        if self.keyfile is None:
+            msg = "Keyfile not loaded yet."
+            raise AttributeError(msg)
+        if self.stop_point_code is None:
+            msg = "No inventory data loaded yet. Call `run` method."
+            raise RuntimeError(msg)
+
+        self._fvsStandID(
+            self._stand_id,
+            self._stand_cn,
+            self._mgmt_id,
+            ct.c_int(0),
+            ct.c_int(0),
+            ct.c_int(0),
+        )
+
+        return {
+            STAND_ID_COLUMN_NAME: self._stand_id.value.decode().strip(),
+            STAND_CN_COLUMN_NAME: self._stand_cn.value.decode().strip(),
+            MGMT_ID_COLUMN_NAME: self._mgmt_id.value.decode().strip(),
+        }
+
+    @fvs_property
+    def summary(self) -> pd.DataFrame | None:
+        """Return a dataframe with FVS Summary Statistics for all initiated cycles.
+
+        The returned dataframe omits cycles that have not yet been initiated, which are
+        identifiable where all values in that row are zero.
+        """
+        self._fvsSummary.argtypes = [
+            np.ctypeslib.ndpointer(np.intc, flags=STR_C_CONTIGUOUS),  # type: ignore[arg-type]
+            ct.POINTER(ct.c_int),
+            ct.POINTER(ct.c_int),
+            ct.POINTER(ct.c_int),
+            ct.POINTER(ct.c_int),
+            ct.POINTER(ct.c_int),
+        ]
+        self._fvsSummary.restype = None
+
+        dims = self.dims
+        if dims[STR_NCYCLES] == 0:
+            return None
+        summary = np.zeros(
+            dtype=np.intc,
+            shape=(dims[STR_NCYCLES] + 1, len(SUMMARY_COLS)),
+        )
+        for i in range(dims[STR_NCYCLES] + 1):
+            self._fvsSummary(
+                summary[i],
+                ct.c_int(i + 1),  # icycle
+                ct.c_int(dims[STR_NCYCLES]),  # ncycles
+                ct.c_int(0),  # maxrow
+                ct.c_int(0),  # maxcol
+                ct.c_int(0),  # rtncode
+            )
+
+        empty_years = (summary == 0).all(axis=1)
+        return pd.DataFrame(
+            summary[~empty_years, :], columns=SUMMARY_COLS
+        ).copy()

--- a/fvs2py/common.py
+++ b/fvs2py/common.py
@@ -94,16 +94,67 @@ def fvs_property(func: Callable[..., T]) -> property:
     return property(wrapper)
 
 
+def no_fvs_library_required(func: Callable[P, T]) -> Callable[P, T]:
+    """Mark a method so `class_requires_fvs_library` leaves it unwrapped.
+
+    Use this to opt a pure-Python helper out of the automatic ``_lib``-loaded
+    guard applied by :func:`class_requires_fvs_library`. The marker is read
+    from the underlying function object during class decoration.
+
+    Args:
+        func: Instance method to leave unguarded.
+
+    Returns:
+        The same function object with a ``_fvs_library_required`` attribute set
+        to ``False``.
+    """
+    func._fvs_library_required = False  # type: ignore[attr-defined]
+    return func
+
+
 def class_requires_fvs_library(cls: ClassT) -> ClassT:
     """Decorator enforcing `function_requires_fvs_library` for all public methods.
 
-    This decorator applies the `function_requires_fvs_library` decorator to all public
-    methods of the class.
+    Walks ``cls.__mro__`` so that public methods contributed by mixins receive
+    the same ``_lib``-loaded guard that methods defined directly on ``cls``
+    get. The first occurrence of each public name wins (respecting MRO), so
+    overrides on ``cls`` are not shadowed by same-named methods on a base.
+
+    Skips:
+      - names that start with ``_`` (private / dunder).
+      - non-callables (e.g. ``property`` descriptors, which are expected to
+        carry their own guard via :func:`fvs_property`).
+      - ``staticmethod`` / ``classmethod`` descriptors — they have no ``self``
+        to inspect and their own guard would have to be different.
+      - methods marked with :func:`no_fvs_library_required`.
+      - methods already wrapped by a previous call (idempotent).
+
+    Args:
+        cls: The class to decorate.
+
+    Returns:
+        The same class, with public methods replaced by ``_lib``-guarded
+        wrappers.
     """
-    for name, method in cls.__dict__.items():
-        if callable(method) and not name.startswith("_"):
-            decorated_method = function_requires_fvs_library()(method)
-            setattr(cls, name, decorated_method)
+    wrapped_names: set[str] = set()
+    for base in cls.__mro__:
+        if base is object:
+            continue
+        for name, method in vars(base).items():
+            if name in wrapped_names:
+                continue
+            if name.startswith("_") or not callable(method):
+                continue
+            if isinstance(method, (staticmethod, classmethod)):
+                continue
+            if getattr(method, "_fvs_library_required", True) is False:
+                continue
+            if getattr(method, "_fvs_wrapped", False):
+                continue
+            wrapped = function_requires_fvs_library()(method)
+            wrapped._fvs_wrapped = True  # type: ignore[attr-defined]
+            setattr(cls, name, wrapped)
+            wrapped_names.add(name)
     return cls
 
 

--- a/fvs2py/tests/test_mixins.py
+++ b/fvs2py/tests/test_mixins.py
@@ -1,0 +1,342 @@
+"""Stub-based unit tests for the focused mixins under ``fvs2py._mixins``.
+
+These tests exercise each mixin's Python-side logic without loading the real
+FVS shared library. Where a mixin method has to invoke a ctypes foreign
+function, the test substitutes a plain Python callable that mutates its
+output-pointer arguments (the ``call_out`` helper passes freshly-allocated
+``ct.c_int`` objects, which look identical to a Python stub).
+"""
+
+from __future__ import annotations
+
+import ctypes as ct
+
+import pytest
+
+from fvs2py._mixins.control import ControlMixin
+from fvs2py._mixins.simulation import SimulationMixin
+from fvs2py._mixins.species import SpeciesMixin
+from fvs2py._mixins.stand import StandMixin
+from fvs2py.common import class_requires_fvs_library, no_fvs_library_required
+from fvs2py.constants import (
+    FVS_ITRNCD_NOT_STARTED,
+    MGMT_ID_COLUMN_NAME,
+    SPECIES_ATTRS,
+    STAND_CN_COLUMN_NAME,
+    STAND_ID_COLUMN_NAME,
+    STR_MAXCYCLES,
+    STR_MAXPLOTS,
+    STR_MAXSPECIES,
+    STR_MAXTREES,
+    STR_NCYCLES,
+    STR_NPLOTS,
+    STR_NTREES,
+)
+from fvs2py.enums import FvsAttributeAccessor
+
+
+class _StubLib:
+    """Sentinel `_lib` attribute used by `@fvs_property` loaded-library checks."""
+
+
+# ---------------------------------------------------------------------------
+# StandMixin
+# ---------------------------------------------------------------------------
+
+
+class _StandStub(StandMixin, ControlMixin):
+    """Minimal StandMixin host that uses Python-callable stubs for ctypes calls.
+
+    Also inherits ControlMixin so ``stop_point_code`` resolves as a property.
+    """
+
+    def __init__(self):
+        self._lib = _StubLib()
+        self.keyfile = None
+        self._stop_point_code = None
+        self._stop_point_year = None
+        self._stand_id = ct.create_string_buffer(26)
+        self._stand_cn = ct.create_string_buffer(40)
+        self._mgmt_id = ct.create_string_buffer(4)
+
+        def fvs_dim_sizes(
+            ntrees, ncycles, nplots, maxtrees, maxspecies, maxplots, maxcycles
+        ):
+            ntrees.value = 11
+            ncycles.value = 22
+            nplots.value = 33
+            maxtrees.value = 44
+            maxspecies.value = 55
+            maxplots.value = 66
+            maxcycles.value = 77
+
+        def fvs_stand_id(stand_id, stand_cn, mgmt_id, *_lengths):
+            stand_id.value = b"stand-001"
+            stand_cn.value = b"cn-42"
+            mgmt_id.value = b"M1"
+
+        self._fvsDimSizes = fvs_dim_sizes
+        self._fvsStandID = fvs_stand_id
+
+
+def test_stand_mixin_dims_returns_named_dict():
+    stub = _StandStub()
+    assert stub.dims == {
+        STR_NTREES: 11,
+        STR_NCYCLES: 22,
+        STR_NPLOTS: 33,
+        STR_MAXTREES: 44,
+        STR_MAXSPECIES: 55,
+        STR_MAXPLOTS: 66,
+        STR_MAXCYCLES: 77,
+    }
+
+
+def test_stand_mixin_stand_ids_without_keyfile_raises():
+    stub = _StandStub()
+    with pytest.raises(AttributeError, match="Keyfile not loaded yet."):
+        stub.stand_ids
+
+
+def test_stand_mixin_stand_ids_without_run_raises():
+    stub = _StandStub()
+    stub.keyfile = "STDIDENT\n"
+    with pytest.raises(
+        RuntimeError,
+        match="No inventory data loaded yet. Call `run` method.",
+    ):
+        stub.stand_ids
+
+
+def test_stand_mixin_stand_ids_returns_decoded_values():
+    stub = _StandStub()
+    stub.keyfile = "STDIDENT\n"
+    stub._stop_point_code = ct.c_int(0)
+    assert stub.stand_ids == {
+        STAND_ID_COLUMN_NAME: "stand-001",
+        STAND_CN_COLUMN_NAME: "cn-42",
+        MGMT_ID_COLUMN_NAME: "M1",
+    }
+
+
+# ---------------------------------------------------------------------------
+# SimulationMixin
+# ---------------------------------------------------------------------------
+
+
+class _SimulationStub(SimulationMixin):
+    def __init__(self, itrncd=0, exit_code=0, restart_code=0):
+        self._lib = _StubLib()
+        self.keyfile = None
+        self._itrncd = ct.c_int(-1)
+
+        def writer(value):
+            def _f(out):
+                out.value = value
+
+            return _f
+
+        self._fvsGetRtnCode = writer(itrncd)
+        self._fvsGetICCode = writer(exit_code)
+        self._fvsGetRestartCode = writer(restart_code)
+
+
+def test_simulation_mixin_itrncd_reads_fvs_output():
+    stub = _SimulationStub(itrncd=2)
+    assert stub.itrncd == 2
+
+
+def test_simulation_mixin_exit_code_reads_fvs_output():
+    stub = _SimulationStub(exit_code=3)
+    assert stub.exit_code == 3
+
+
+def test_simulation_mixin_restart_code_reads_fvs_output():
+    stub = _SimulationStub(restart_code=100)
+    assert stub.restart_code == 100
+
+
+def test_simulation_mixin_run_without_keyfile_raises():
+    stub = _SimulationStub()
+    with pytest.raises(AttributeError, match="No keyfile loaded yet."):
+        stub.run()
+
+
+# ---------------------------------------------------------------------------
+# ControlMixin
+# ---------------------------------------------------------------------------
+
+
+class _ControlStub(ControlMixin):
+    def __init__(self):
+        self._lib = _StubLib()
+        self._itrncd = ct.c_int(FVS_ITRNCD_NOT_STARTED)
+        self._stop_point_code = None
+        self._stop_point_year = None
+        self._fvsSetStoppointCodes = lambda *_args: None
+
+
+def test_control_mixin_stop_point_code_returns_none_when_unset():
+    stub = _ControlStub()
+    assert stub.stop_point_code is None
+
+
+def test_control_mixin_stop_point_year_returns_none_when_unset():
+    stub = _ControlStub()
+    assert stub.stop_point_year is None
+
+
+def test_control_mixin_set_stop_point_codes_populates_buffers():
+    stub = _ControlStub()
+    stub.set_stop_point_codes(3, 2025)
+    assert stub.stop_point_code == 3
+    assert stub.stop_point_year == 2025
+
+
+@pytest.mark.parametrize("invalid", [-2, 8, 10, -5])
+def test_control_mixin_set_stop_point_codes_rejects_out_of_range(invalid):
+    stub = _ControlStub()
+    with pytest.raises(ValueError, match="Invalid value for stop_point_code"):
+        stub.set_stop_point_codes(invalid, 0)
+
+
+def test_control_mixin_set_stop_point_codes_rejects_year_without_code():
+    stub = _ControlStub()
+    with pytest.raises(
+        ValueError,
+        match="Must specify stop_point_year if also specifying stop_point_code",
+    ):
+        stub.set_stop_point_codes(None, 2025)
+
+
+# ---------------------------------------------------------------------------
+# SpeciesMixin
+# ---------------------------------------------------------------------------
+
+
+class _SpeciesStub(SpeciesMixin):
+    def __init__(self):
+        self._lib = _StubLib()
+        self._species_attrs = dict.fromkeys(SPECIES_ATTRS)
+
+
+def test_species_mixin_species_attr_unknown_name_raises_nameerror():
+    stub = _SpeciesStub()
+    with pytest.raises(NameError, match="Invalid variable requested"):
+        stub._species_attr("not-a-real-attr", FvsAttributeAccessor.GET)
+
+
+def test_species_mixin_species_attr_set_without_arr_raises_typeerror():
+    stub = _SpeciesStub()
+    # `_species_attr` reads `self.dims` before the arr-None guard; since
+    # `dims` is not on SpeciesMixin, an instance attribute shadows fine.
+    stub.dims = {STR_MAXSPECIES: 1}
+    attr = next(iter(SPECIES_ATTRS))
+    with pytest.raises(
+        TypeError, match="Must provide `arr` if `action` is 'set'"
+    ):
+        stub._species_attr(attr, FvsAttributeAccessor.SET, None)
+
+
+# ---------------------------------------------------------------------------
+# class_requires_fvs_library: MRO walk, marker opt-out, static/class skip
+# ---------------------------------------------------------------------------
+
+
+def test_class_requires_fvs_library_wraps_public_methods_from_mixins():
+    class MixinA:
+        def alpha(self):
+            return "alpha"
+
+    class MixinB:
+        def beta(self):
+            return "beta"
+
+    @class_requires_fvs_library
+    class Host(MixinA, MixinB):
+        pass
+
+    obj = Host()
+    obj._lib = None
+    with pytest.raises(
+        RuntimeError, match="FVS library not loaded, unable to call alpha."
+    ):
+        obj.alpha()
+    with pytest.raises(
+        RuntimeError, match="FVS library not loaded, unable to call beta."
+    ):
+        obj.beta()
+
+
+def test_class_requires_fvs_library_subclass_override_wins_over_base():
+    class Base:
+        def method(self):
+            return "base"
+
+    @class_requires_fvs_library
+    class Sub(Base):
+        def method(self):
+            return "sub"
+
+    obj = Sub()
+    obj._lib = _StubLib()
+    assert obj.method() == "sub"
+
+
+def test_class_requires_fvs_library_honors_no_fvs_library_required():
+    @class_requires_fvs_library
+    class Host:
+        @no_fvs_library_required
+        def pure_python(self):
+            return "ok"
+
+        def needs_lib(self):
+            return "guarded"
+
+    obj = Host()
+    obj._lib = None
+    assert obj.pure_python() == "ok"
+    with pytest.raises(
+        RuntimeError, match="FVS library not loaded, unable to call needs_lib."
+    ):
+        obj.needs_lib()
+
+
+def test_class_requires_fvs_library_skips_staticmethod_and_classmethod():
+    @class_requires_fvs_library
+    class Host:
+        @staticmethod
+        def static_method():
+            return "static"
+
+        @classmethod
+        def class_method(cls):
+            return "class"
+
+    # `_lib` is not set on any instance — a wrapped method would raise
+    # RuntimeError. These are NOT wrapped, so they work without state.
+    assert Host.static_method() == "static"
+    assert Host.class_method() == "class"
+
+
+def test_class_requires_fvs_library_skips_private_methods():
+    @class_requires_fvs_library
+    class Host:
+        def _private(self):
+            return "private"
+
+    obj = Host()
+    obj._lib = None
+    assert obj._private() == "private"
+
+
+def test_class_requires_fvs_library_skips_property_descriptors():
+    @class_requires_fvs_library
+    class Host:
+        @property
+        def plain(self):
+            return "plain"
+
+    obj = Host()
+    obj._lib = None
+    assert obj.plain == "plain"


### PR DESCRIPTION
## Summary

Split the monolithic `FVS` class into four focused mixins and strengthen the library-loaded guard so it applies across inherited methods.

- New `fvs2py/_mixins/` package with four mixins, each owning a coherent slice of behavior:
  - `SimulationMixin` — `itrncd`, `exit_code`, `restart_code`, `run`.
  - `ControlMixin` — `load_keyfile`, `set_stop_point_codes`, `stop_point_code`/`stop_point_year` getters.
  - `StandMixin` — `dims`, `stand_ids`, `summary`.
  - `SpeciesMixin` — `species`, `species_codes`, `species_attrs`, `get_species_attr`, `set_species_attr`, `_species_attr`.
- `_base.py` is now a thin assembly class: `FVS(SpeciesMixin, StandMixin, SimulationMixin, ControlMixin, FvsCore)` owning only `_initialize_attributes` and `_reload_fvs`.
- `class_requires_fvs_library` now walks `cls.__mro__` (not just `cls.__dict__`), so public methods inherited from mixins receive the same `_lib`-loaded guard that methods defined on `cls` do.
- New `@no_fvs_library_required` marker lets pure-Python helpers opt out of the guard.
- Guard decorator skips `staticmethod`/`classmethod`/`property` descriptors and private names; wraps each public name once (first occurrence in MRO wins, so overrides on `cls` are not shadowed by a same-named method on a base).
- Each mixin declares class-level type annotations for the attributes and sibling-mixin methods it consumes (`_fvsXxx: ct._FuncPointer`, `keyfile: str | None`, `set_stop_point_codes: Callable[..., None]`, etc.), documenting the mixin contract and getting mypy's cross-mixin `attr-defined` complaints down to the pre-PR-1 baseline.

## What did NOT change

- Public API: no attributes, method names, signatures, or return types changed.
- Behavior: `run()` still eagerly runs to completion, `load_keyfile` still reloads on reuse with the same warning, `stop_point_code`/`stop_point_year` still return `None` before being set, all existing error types and messages are preserved.
- Status codes: `FVS_ITRNCD_*` and the `range(-1, 8)` check stay as-is (those move to `IntEnum`s in a follow-up PR).

## Test plan

- [x] Existing `fvs2py/tests/test_base.py` (54 tests) and `test_core.py` (4 tests) pass unchanged, including:
  - `test_decorator_requires_fvs_library_following_unload` — exercises the MRO walk (`run` is defined on `SimulationMixin`, not on `FVS`).
  - `test_fvs_methods_require_fvs_library` — exercises `@fvs_property` guard on `species_attrs` via `SpeciesMixin`.
  - `test_reload_fvs`, `test_load_keyfile_after_run`, `test_keyfile_reload_warning` — confirm the `_reload_fvs` + `_initialize_attributes` wiring still works when `load_keyfile` is called on an already-run FVS.
- [x] New `fvs2py/tests/test_mixins.py` (24 tests) exercises each mixin in isolation against lightweight Python stubs (no DLL load), plus the decorator itself:
  - `StandMixin.dims`, `stand_ids` guard paths, `stand_ids` happy path.
  - `SimulationMixin.itrncd`/`exit_code`/`restart_code` read-through, `run` without keyfile raises.
  - `ControlMixin` `stop_point_code`/`stop_point_year` sentinels, `set_stop_point_codes` validation (out-of-range + year-without-code).
  - `SpeciesMixin._species_attr` name validation and SET-without-arr guard.
  - `class_requires_fvs_library` — wraps mixin-inherited methods, respects subclass overrides, honors `@no_fvs_library_required`, skips `staticmethod`/`classmethod`/`property`/private names.