### PR TITLE
pandas stubs for mypy

### DIFF
--- a/fvs2py/_mixins/species.py
+++ b/fvs2py/_mixins/species.py
@@ -7,7 +7,7 @@ import warnings
 
 import numpy as np
 import numpy.typing as npt
-import pandas as pd  # type: ignore[import-untyped]
+import pandas as pd
 
 from fvs2py.common import fvs_property
 from fvs2py.constants import (

--- a/fvs2py/_mixins/stand.py
+++ b/fvs2py/_mixins/stand.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import ctypes as ct
 
 import numpy as np
-import pandas as pd  # type: ignore[import-untyped]
+import pandas as pd
 
 from fvs2py.common import call_out, fvs_property
 from fvs2py.constants import (

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 ipykernel
+pandas-stubs
 pre-commit
 pytest
 pytest-mock


### PR DESCRIPTION
## Summary

Adds `pandas-stubs` to `requirements-dev.txt` so `mypy` can type-check the `pandas` imports introduced in the PR 2 mixin split. Drops the `# type: ignore[import-untyped]` comments that were a temporary workaround until the stubs were installed.

## Changes

- `requirements-dev.txt`: add `pandas-stubs` (alphabetical slot between  `ipykernel` and `pre-commit`).
- `fvs2py/_mixins/species.py`: remove `# type: ignore[import-untyped]` from  the `pandas` import.
- `fvs2py/_mixins/stand.py`: same.

## Test plan

- [x] `ruff check fvs2py/` clean.
- [x] `pytest fvs2py/tests/` — 125/125 pass.
- [x] `mypy` no longer reports any `import-untyped` errors for `pandas`. 