### PR TITLE
setters for stopping

### DIFF
--- a/fvs2py/_mixins/control.py
+++ b/fvs2py/_mixins/control.py
@@ -9,6 +9,7 @@ import warnings
 from collections.abc import Callable
 from pathlib import Path
 
+from fvs2py.common import fvs_property
 from fvs2py.enums import FvsItrnCode, FvsStopPointCode
 from fvs2py.keyfile import validate_single_stand
 
@@ -34,7 +35,7 @@ class ControlMixin:
     itrncd: int
     _reload_fvs: Callable[[], None]
 
-    @property
+    @fvs_property
     def stop_point_code(self) -> int | None:
         """A code used to instruct FVS when to stop during a cycle.
 
@@ -50,22 +51,48 @@ class ControlMixin:
          7 : Stop just after input is read but before missing values are imputed
                 (tree heights and crown ratios, for example) and model
                 calibration (argument stptyr is ignored).
+
+        Assigning to this property delegates to :meth:`set_stop_point_codes`,
+        preserving the currently-configured ``stop_point_year`` (or ``0`` if
+        year has not been set).
         """
         if self._stop_point_code is not None:
             return self._stop_point_code.value
         return None
 
-    @property
+    @stop_point_code.setter  # type: ignore[no-redef]
+    def stop_point_code(self, value: int) -> None:
+        year = (
+            self._stop_point_year.value
+            if self._stop_point_year is not None
+            else 0
+        )
+        self.set_stop_point_codes(value, year)
+
+    @fvs_property
     def stop_point_year(self) -> int | None:
         """A code indicating which cycles FVS should stop at.
 
         0 : Never stop.
         1 : Stop at every cycle.
         YYYY : A specific year during the simulation period.
+
+        Assigning to this property delegates to :meth:`set_stop_point_codes`,
+        preserving the currently-configured ``stop_point_code`` (or ``0`` if
+        code has not been set).
         """
         if self._stop_point_year is not None:
             return self._stop_point_year.value
         return None
+
+    @stop_point_year.setter  # type: ignore[no-redef]
+    def stop_point_year(self, value: int) -> None:
+        code = (
+            self._stop_point_code.value
+            if self._stop_point_code is not None
+            else 0
+        )
+        self.set_stop_point_codes(code, value)
 
     def load_keyfile(
         self,

--- a/fvs2py/_mixins/simulation.py
+++ b/fvs2py/_mixins/simulation.py
@@ -94,7 +94,7 @@ class SimulationMixin:
         stop_point_code: int = 0,
         stop_point_year: int = 0,
     ) -> None:
-        """Run a single-stand FVS simulation to completion.
+        """Run FVS until the stand completes or a stop point is reached.
 
         The call stays eager: when the stand finishes (FVS reports
         ``restart_code == FvsRestartCode.DONE_RUNNING_STAND``), :meth:`run`

--- a/fvs2py/common.py
+++ b/fvs2py/common.py
@@ -70,28 +70,76 @@ def function_requires_fvs_library() -> Callable[
     return decorator
 
 
-def fvs_property(func: Callable[..., T]) -> property:
-    """A property decorator that checks if the FVS library is loaded before accessing.
+class fvs_property:
+    """Property descriptor with an FVS-library-loaded guard.
 
-    This combines @property with a check for self._lib. This decorator will help ensure
-    that the FVS library is loaded before accessing the property. If the FVS library
-    has been unloaded without this protection, a segmentation fault would occur.
+    Behaves like the built-in :class:`property`, but before invoking either the
+    getter or the setter it checks that the instance has a non-``None`` ``_lib``
+    attribute and raises :class:`RuntimeError` otherwise. Guarding here prevents
+    the segmentation fault that would result from calling into an unloaded FVS
+    shared library.
+
+    Supports the standard ``@<name>.setter`` fluent syntax, mirroring the
+    stdlib :class:`property`. Setters receive the same ``_lib``-loaded guard
+    as getters.
 
     Args:
-        func: The property getter function to wrap.
-
-    Returns:
-        A property descriptor with FVS library checking.
+        fget: Getter function taking ``self`` and returning the property
+            value.
+        fset: Optional setter function taking ``self`` and the new value.
     """
 
-    @functools.wraps(func)
-    def wrapper(self) -> T:
-        if not hasattr(self, "_lib") or self._lib is None:
-            msg = f"FVS library not loaded, unable to access {func.__name__} property."
-            raise RuntimeError(msg)
-        return func(self)
+    def __init__(
+        self,
+        fget: Callable[[Any], Any] | None = None,
+        fset: Callable[[Any, Any], None] | None = None,
+    ) -> None:
+        self.fget = fget
+        self.fset = fset
+        self.__doc__ = fget.__doc__ if fget is not None else None
+        self.__name__ = fget.__name__ if fget is not None else ""
 
-    return property(wrapper)
+    def _check_lib(self, obj: Any, action: str) -> None:
+        """Raise if ``obj._lib`` is missing or ``None``."""
+        if not hasattr(obj, "_lib") or obj._lib is None:
+            msg = (
+                f"FVS library not loaded, unable to "
+                f"{action} {self.__name__} property."
+            )
+            raise RuntimeError(msg)
+
+    def __get__(self, obj: Any, objtype: type | None = None) -> Any:
+        """Invoke the wrapped getter after verifying the library is loaded."""
+        if obj is None:
+            return self
+        if self.fget is None:
+            msg = f"property {self.__name__!r} has no getter"
+            raise AttributeError(msg)
+        self._check_lib(obj, "access")
+        return self.fget(obj)
+
+    def __set__(self, obj: Any, value: Any) -> None:
+        """Invoke the wrapped setter after verifying the library is loaded."""
+        if self.fset is None:
+            msg = f"property {self.__name__!r} has no setter"
+            raise AttributeError(msg)
+        self._check_lib(obj, "set")
+        self.fset(obj, value)
+
+    def setter(self, fset: Callable[[Any, Any], None]) -> fvs_property:
+        """Return a new :class:`fvs_property` combining ``self.fget`` with ``fset``.
+
+        Supports the ``@<name>.setter`` fluent syntax used with the stdlib
+        :class:`property`.
+
+        Args:
+            fset: Setter function taking ``self`` and a new value.
+
+        Returns:
+            A new :class:`fvs_property` sharing this descriptor's getter and
+            using ``fset`` as its setter.
+        """
+        return type(self)(self.fget, fset)
 
 
 def no_fvs_library_required(func: Callable[P, T]) -> Callable[P, T]:

--- a/fvs2py/tests/test_base.py
+++ b/fvs2py/tests/test_base.py
@@ -126,6 +126,30 @@ def test_invalid_stop_point_code(fvs, stop_point_code):
         assert fvs.stop_point_year == 0
 
 
+def test_stop_point_code_setter(fvs):
+    fvs.stop_point_code = FvsStopPointCode.AFTER_FIRST_EVMON
+    assert fvs.stop_point_code == FvsStopPointCode.AFTER_FIRST_EVMON
+    assert fvs.stop_point_year == 0
+
+
+def test_stop_point_year_setter(fvs):
+    fvs.stop_point_year = 2030
+    assert fvs.stop_point_code == 0
+    assert fvs.stop_point_year == 2030
+
+
+def test_stop_point_setters_preserve_prior_assignments(fvs):
+    fvs.stop_point_code = FvsStopPointCode.BEFORE_FIRST_EVMON
+    fvs.stop_point_year = 2025
+    assert fvs.stop_point_code == FvsStopPointCode.BEFORE_FIRST_EVMON
+    assert fvs.stop_point_year == 2025
+
+
+def test_stop_point_code_setter_validates(fvs):
+    with pytest.raises(ValueError, match="Invalid value for stop_point_code"):
+        fvs.stop_point_code = 99
+
+
 def test_run_with_keyfile_succeeds(fvs, keyfile):
     assert fvs.itrncd == FvsItrnCode.NOT_STARTED
 

--- a/fvs2py/tests/test_common.py
+++ b/fvs2py/tests/test_common.py
@@ -1,0 +1,108 @@
+"""Unit tests for helpers in :mod:`fvs2py.common`.
+
+These tests exercise the descriptor protocol of :class:`fvs2py.common.fvs_property`
+without loading the real FVS shared library. A sentinel ``_StubLib`` class stands
+in for the attribute the guard checks, so the descriptor behaves as it would on
+a fully-initialized :class:`fvs2py.FVS` instance.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fvs2py.common import fvs_property
+
+
+class _StubLib:
+    """Sentinel `_lib` attribute used by `fvs_property` loaded-library checks."""
+
+
+class _Holder:
+    """Minimal host exercising the descriptor under test.
+
+    Declared as a module-level class rather than a nested class so the
+    descriptor binds to a stable owner across every test function.
+    """
+
+    def __init__(self, value: int = 0) -> None:
+        self._lib: _StubLib | None = _StubLib()
+        self._value = value
+
+    @fvs_property
+    def value(self) -> int:
+        return self._value
+
+    @value.setter  # type: ignore[no-redef]
+    def value(self, new_value: int) -> None:
+        self._value = new_value
+
+    @fvs_property
+    def read_only(self) -> int:
+        return self._value
+
+
+def test_fvs_property_getter_returns_value_when_library_loaded():
+    holder = _Holder(value=7)
+    assert holder.value == 7
+
+
+def test_fvs_property_setter_updates_value():
+    holder = _Holder(value=0)
+    holder.value = 42
+    assert holder.value == 42
+    assert holder._value == 42
+
+
+def test_fvs_property_getter_raises_when_library_missing():
+    holder = _Holder(value=3)
+    holder._lib = None
+    with pytest.raises(
+        RuntimeError,
+        match="FVS library not loaded, unable to access value property.",
+    ):
+        holder.value
+
+
+def test_fvs_property_setter_raises_when_library_missing():
+    holder = _Holder(value=0)
+    holder._lib = None
+    with pytest.raises(
+        RuntimeError,
+        match="FVS library not loaded, unable to set value property.",
+    ):
+        holder.value = 1
+
+
+def test_fvs_property_without_setter_rejects_assignment():
+    holder = _Holder(value=0)
+    with pytest.raises(AttributeError, match="has no setter"):
+        holder.read_only = 5
+
+
+def test_fvs_property_class_access_returns_descriptor():
+    descriptor = _Holder.value
+    assert isinstance(descriptor, fvs_property)
+    assert descriptor.__name__ == "value"
+
+
+def test_fvs_property_preserves_getter_docstring():
+    def getter(_self: object) -> int:
+        """Custom docstring."""
+        return 0
+
+    descriptor = fvs_property(getter)
+    assert descriptor.__doc__ == "Custom docstring."
+
+
+def test_fvs_property_setter_builds_new_descriptor_with_same_getter():
+    def getter(_self: object) -> int:
+        return 1
+
+    def setter(_self: object, _value: int) -> None:
+        return None
+
+    base = fvs_property(getter)
+    with_setter = base.setter(setter)
+    assert with_setter is not base
+    assert with_setter.fget is base.fget
+    assert with_setter.fset is setter

--- a/fvs2py/tests/test_mixins.py
+++ b/fvs2py/tests/test_mixins.py
@@ -322,6 +322,42 @@ def test_control_mixin_set_stop_point_codes_rejects_year_without_code():
         stub.set_stop_point_codes(None, 2025)
 
 
+def test_control_mixin_stop_point_code_setter_delegates():
+    stub = _ControlStub()
+    stub.stop_point_code = 3
+    assert stub.stop_point_code == 3
+    assert stub.stop_point_year == 0
+
+
+def test_control_mixin_stop_point_year_setter_delegates():
+    stub = _ControlStub()
+    stub.stop_point_year = 2025
+    assert stub.stop_point_code == 0
+    assert stub.stop_point_year == 2025
+
+
+def test_control_mixin_stop_point_code_setter_preserves_existing_year():
+    stub = _ControlStub()
+    stub.set_stop_point_codes(1, 2020)
+    stub.stop_point_code = 4
+    assert stub.stop_point_code == 4
+    assert stub.stop_point_year == 2020
+
+
+def test_control_mixin_stop_point_year_setter_preserves_existing_code():
+    stub = _ControlStub()
+    stub.set_stop_point_codes(2, 2015)
+    stub.stop_point_year = 2030
+    assert stub.stop_point_code == 2
+    assert stub.stop_point_year == 2030
+
+
+def test_control_mixin_stop_point_code_setter_validates():
+    stub = _ControlStub()
+    with pytest.raises(ValueError, match="Invalid value for stop_point_code"):
+        stub.stop_point_code = 99
+
+
 # ---------------------------------------------------------------------------
 # SpeciesMixin
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Converts `fvs_property` from a getter-wrapping function into a full descriptor class with `.setter` support, then uses that to expose `stop_point_code` and `stop_point_year` as writable properties that delegate to the existing `set_stop_point_codes` method.

## Motivation

`set_stop_point_codes(code, year)` is the only way to configure a pause in an FVS run, and its paired-argument signature forces callers to re-specify whichever axis they did not actually want to change. Exposing `fvs.stop_point_code = ...` and `fvs.stop_point_year = ...` as independent writable properties lets callers mutate one axis at a time without having to remember what the other axis is currently set to. The descriptor rewrite is the minimum machinery needed to make the setters also carry the `_lib`-loaded guard that the getters already had.

## Changes

### `fvs_property` is now a descriptor class

`fvs2py/common.py` replaces the function-wrapping implementation with a descriptor class that supports the standard `@<name>.setter` fluent syntax. Both `__get__` and `__set__` check `self._lib` before invoking the wrapped callable; the read-path error message (`"FVS library not loaded, unable to access <name> property."`) is preserved verbatim, and the write path raises the parallel `"FVS library not loaded, unable to set <name> property."`. All existing `@fvs_property` use sites keep working without changes.

### Writable stop-point properties

`fvs2py/_mixins/control.py` switches `stop_point_code` and `stop_point_year` from plain `@property` to `@fvs_property` (so they now share the library-loaded guard) and adds setters that delegate to `set_stop_point_codes`. Each setter preserves the other axis' current value (or defaults to `0` when unset), so `fvs.stop_point_year = 2030` does not clobber a previously-configured `stop_point_code`, and vice versa. Setting an invalid `stop_point_code` raises the same `ValueError` that `set_stop_point_codes` already raises.

### Tests

Three test files receive additions:

- `fvs2py/tests/test_common.py` (new) covers the descriptor protocol without a real FVS library: getter and setter happy paths, library-missing guards on both paths, a read-only descriptor rejecting assignment, class-level access returning the descriptor, docstring preservation, and `.setter` returning a new descriptor sharing the original getter.
- `fvs2py/tests/test_mixins.py` adds stub-based tests for `ControlMixin` covering setter delegation, preservation of existing values when only one axis is changed, and validation rejection on invalid codes.
- `fvs2py/tests/test_base.py` adds integration tests against the real FVS library covering the same setter paths end-to-end.

## Notes on trade-offs

Two `# type: ignore[no-redef]` comments sit on the `@stop_point_code.setter` and `@stop_point_year.setter` decorator lines because mypy only special-cases the stdlib `property` class for the `@name.setter` redefinition pattern; any user-defined descriptor that mirrors the same fluent API trips the `no-redef` check. The alternative (a mypy plugin) is not worth the maintenance cost for two setters.

Converting `stop_point_code` and `stop_point_year` from plain `@property` to `@fvs_property` is a behavioral change in exactly one scenario: reading either property after `_unload_fvs()` now raises `RuntimeError` instead of returning the last-known value or `None`. That brings them into line with every other FVS-side property (`species_attrs`, `dims`, etc.) and is covered by the existing `test_fvs_methods_require_fvs_library` pattern.

## Validation

`ruff check` and `ruff format --check` pass on all touched files. `mypy` passes; `pytest` passes 163 tests, up from 146, all additions contributed by this PR.