### PR TITLE
migrates SimulationMixin to registry of FVS_ROUTINES

### DIFF
--- a/fvs2py/_core.py
+++ b/fvs2py/_core.py
@@ -4,7 +4,9 @@ import ctypes as ct
 import logging
 import os
 from pathlib import Path
+from typing import Any
 
+from fvs2py._routines import FVS_ROUTINES
 from fvs2py._signatures import FVS_SIGNATURES
 from fvs2py.common import load_dll, unload_dll
 from fvs2py.constants import NEEDED_ROUTINES
@@ -105,6 +107,42 @@ class FvsCore:
                 ]
             )
             raise ImportError(msg)
+
+    def _invoke(self, name: str, /, **kwargs: Any) -> Any:
+        """Dispatch a call to a registered FVS routine.
+
+        Looks up ``name`` in :data:`fvs2py._routines.FVS_ROUTINES`, resolves
+        the bound foreign function at ``self._<name>``, and hands off to
+        :meth:`fvs2py._routines.Routine.call` for argtype resolution, OUT
+        buffer allocation, return-code policy dispatch, and result unwrap.
+
+        Args:
+            name: Un-mangled FVS routine name (the same key used by
+                :data:`NEEDED_ROUTINES`).
+            **kwargs: Per-parameter values; see the relevant
+                :class:`fvs2py._routines.Routine` declaration for the
+                expected kwarg names.
+
+        Returns:
+            Whatever :meth:`fvs2py._routines.Routine.call` returns for the
+            routine: ``None`` when there are no non-rc OUT params, an
+            unwrapped scalar for a single OUT param, or a dict keyed by
+            OUT-param name for multiple OUT params.
+
+        Raises:
+            NotImplementedError: If ``name`` is not registered in
+                :data:`FVS_ROUTINES` (either a typo or the routine has not
+                been migrated to the registry yet).
+            AttributeError: If the corresponding foreign function has not
+                been resolved on ``self``.
+        """
+        try:
+            routine = FVS_ROUTINES[name]
+        except KeyError as exc:
+            msg = f"{name!r} is not registered in FVS_ROUTINES"
+            raise NotImplementedError(msg) from exc
+        func = getattr(self, f"_{name}")
+        return routine.call(func, **kwargs)
 
     def _load_fvs(self) -> None:
         """Load the FVS shared library into ``self._lib``, unloading any prior handle."""

--- a/fvs2py/_mixins/simulation.py
+++ b/fvs2py/_mixins/simulation.py
@@ -5,25 +5,22 @@ from __future__ import annotations
 import ctypes as ct
 import logging
 from collections.abc import Callable
+from typing import Any
 
-from fvs2py.common import call_out, fvs_property
+from fvs2py.common import fvs_property
 from fvs2py.enums import FvsItrnCode, FvsRestartCode, FvsSimulationState
 
 
 class SimulationMixin:
     """Expose FVS simulation status codes and the top-level :meth:`run` loop.
 
-    Assumes the composed class provides the foreign-function attributes
-    ``_fvs``, ``_fvsGetICCode``, ``_fvsGetRtnCode``, ``_fvsGetRestartCode``
-    (resolved by :class:`fvs2py._core.FvsCore`) plus the Python-side buffers
-    ``_itrncd`` and ``_state``, the ``keyfile`` attribute, and the
-    :meth:`set_stop_point_codes` helper contributed by :class:`ControlMixin`.
+    Assumes the composed class provides :meth:`fvs2py._core.FvsCore._invoke`
+    plus the Python-side buffers ``_itrncd`` and ``_state``, the ``keyfile``
+    attribute, and the :meth:`set_stop_point_codes` helper contributed by
+    :class:`ControlMixin`.
     """
 
-    _fvs: ct._FuncPointer
-    _fvsGetICCode: ct._FuncPointer
-    _fvsGetRtnCode: ct._FuncPointer
-    _fvsGetRestartCode: ct._FuncPointer
+    _invoke: Callable[..., Any]
     _itrncd: ct.c_int
     _state: FvsSimulationState
     keyfile: str | None
@@ -42,7 +39,7 @@ class SimulationMixin:
           3 - Extension or group activities error.
           4 - Scratch file error.
         """
-        return call_out(self._fvsGetICCode)
+        return self._invoke("fvsGetICCode")
 
     @fvs_property
     def itrncd(self) -> int:
@@ -55,7 +52,7 @@ class SimulationMixin:
          2: indicates that FVS has finished processing all the stands; new input
                 can be specified.
         """
-        return call_out(self._fvsGetRtnCode)
+        return self._invoke("fvsGetRtnCode")
 
     @fvs_property
     def restart_code(self) -> int:
@@ -71,19 +68,19 @@ class SimulationMixin:
         100: Stop was done after a stand has been simulated but prior to
                 starting a subsequent stand.
         """
-        return call_out(self._fvsGetRestartCode)
+        return self._invoke("fvsGetRestartCode")
 
     def _run_cycles(self) -> None:
         """Advance FVS until the current stand pauses or reaches stand-done.
 
         Shared inner loop used by both :meth:`run` and :meth:`run_batch`: call
-        ``_fvs`` while FVS reports a good running state, breaking out the
+        ``fvs`` while FVS reports a good running state, breaking out the
         moment ``restart_code`` leaves ``INITIALIZED`` (either a stop-point
         pause or the ``DONE_RUNNING_STAND`` marker).
         """
         while self.itrncd == FvsItrnCode.GOOD_RUNNING_STATE:
             logging.debug("itrncd in GOOD_RUNNING_STATE.")
-            self._fvs(self._itrncd)
+            self._invoke("fvs", itrncd=self._itrncd)
             logging.debug(f"Ran _fvs routine, itrncd is {self.itrncd}")
             if self.restart_code != FvsRestartCode.INITIALIZED:
                 logging.debug("restart code non-zero, halting run loop.")
@@ -148,7 +145,7 @@ class SimulationMixin:
             self._run_cycles()
             if self.restart_code == FvsRestartCode.DONE_RUNNING_STAND:
                 logging.debug("Stand complete; flushing output.")
-                self._fvs(self._itrncd)
+                self._invoke("fvs", itrncd=self._itrncd)
             self._state = FvsSimulationState.COMPLETE
         except Exception:
             self._state = FvsSimulationState.ERROR

--- a/fvs2py/_routines.py
+++ b/fvs2py/_routines.py
@@ -11,14 +11,11 @@ Mixin methods own Python-facing ergonomics and derive dependent args (e.g.
 ``nattr = len(attr)``, ``ntrees = len(values)``) before handing a
 fully-specified kwarg dict to :meth:`FvsCore._invoke`. The registry itself
 stays free of derivation or validation logic.
-
-This module ships the scaffolding only: the :data:`FVS_ROUTINES` mapping
-starts empty and is populated by subsequent PRs as each mixin migrates to
-the invoker.
 """
 
 from __future__ import annotations
 
+import ctypes as ct
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, replace
 from enum import Flag, auto
@@ -292,11 +289,50 @@ def attr_accessor_policy(rc: int) -> None:
 
 
 _RAW_ROUTINES: dict[str, Routine] = {
-    # Registry seeds are intentionally empty in this scaffolding commit.
-    # Each follow-up PR adds its routine's :class:`Routine` alongside the
-    # corresponding mixin migration so every entry lands with a matching
-    # call site. Insertion order is the un-mangled FVS routine name; each
-    # entry lists its params in Fortran declaration order.
+    # Entries are added alongside the corresponding mixin migration so every
+    # routine ships with a matching call site. Insertion order is the
+    # un-mangled FVS routine name; each entry lists its params in Fortran
+    # declaration order.
+    "fvs": Routine(
+        params=(
+            Param(
+                name="itrncd",
+                ctype=ct.POINTER(ct.c_int),
+                intent=Intent.INOUT,
+            ),
+        ),
+        rc_param=None,
+    ),
+    "fvsGetICCode": Routine(
+        params=(
+            Param(
+                name="ic_code",
+                ctype=ct.POINTER(ct.c_int),
+                intent=Intent.OUT,
+            ),
+        ),
+        rc_param=None,
+    ),
+    "fvsGetRtnCode": Routine(
+        params=(
+            Param(
+                name="rtn_code",
+                ctype=ct.POINTER(ct.c_int),
+                intent=Intent.OUT,
+            ),
+        ),
+        rc_param=None,
+    ),
+    "fvsGetRestartCode": Routine(
+        params=(
+            Param(
+                name="restart_code",
+                ctype=ct.POINTER(ct.c_int),
+                intent=Intent.OUT,
+            ),
+        ),
+        rc_param=None,
+    ),
 }
 
 
@@ -306,8 +342,7 @@ FVS_ROUTINES: Mapping[str, Routine] = MappingProxyType(
 """Immutable registry of FVS routine call descriptions.
 
 Keyed by the un-mangled FVS routine name (matching :data:`NEEDED_ROUTINES`).
-The registry ships empty in the scaffolding commit; entries are added by
-later PRs as each mixin migrates to :meth:`FvsCore._invoke`. Routines not
-(yet) described here remain resolvable through :class:`FvsCore` without the
-registry applying a signature to them.
+Entries are added as each mixin migrates to :meth:`FvsCore._invoke`; routines
+not (yet) described here remain resolvable through :class:`FvsCore` without
+the registry applying a signature to them.
 """

--- a/fvs2py/_signatures.py
+++ b/fvs2py/_signatures.py
@@ -10,6 +10,10 @@ Only routines with a static argument shape live here. Routines whose argument
 shapes depend on runtime dimensions (``fvsSummary``, ``fvsSpeciesAttr``,
 ``fvsTreeAttr``) still set ``argtypes`` locally before calling, since the
 shapes cannot be decided at import time.
+
+This mapping is being progressively retired in favor of the declarative
+:data:`fvs2py._routines.FVS_ROUTINES` registry; entries are removed as each
+mixin migrates to :meth:`fvs2py._core.FvsCore._invoke`.
 """
 
 from __future__ import annotations
@@ -35,11 +39,7 @@ class Signature(NamedTuple):
 
 FVS_SIGNATURES: Mapping[str, Signature] = MappingProxyType(
     {
-        "fvs": Signature((ct.POINTER(ct.c_int),)),
         "fvsDimSizes": Signature((ct.POINTER(ct.c_int),) * 7),
-        "fvsGetICCode": Signature((ct.POINTER(ct.c_int),)),
-        "fvsGetRtnCode": Signature((ct.POINTER(ct.c_int),)),
-        "fvsGetRestartCode": Signature((ct.POINTER(ct.c_int),)),
         "fvsSetStoppointCodes": Signature((ct.POINTER(ct.c_int),) * 2),
         "fvsSetCmdLine": Signature(
             (ct.c_char_p, ct.POINTER(ct.c_int), ct.POINTER(ct.c_int)),

--- a/fvs2py/tests/test_core.py
+++ b/fvs2py/tests/test_core.py
@@ -1,3 +1,5 @@
+import ctypes as ct
+
 import pytest
 
 from fvs2py._core import FvsCore
@@ -52,3 +54,45 @@ def test_cdll_load_reformatted_routines():
     assert fvs.variant == "YZ"
     for routine in NEEDED_ROUTINES:
         assert hasattr(fvs, f"_{routine}")
+
+
+# ---------------------------------------------------------------------------
+# FvsCore._invoke — dispatch through FVS_ROUTINES
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("mock_valid_fvs_dll")
+def test_invoke_dispatches_to_registered_routine_and_returns_out_value():
+    fvs = FvsCore("/not/a/real/dir/FVSxx.so")
+
+    def writer(code):
+        code.value = 7
+
+    fvs._fvsGetICCode = writer
+    assert fvs._invoke("fvsGetICCode") == 7
+
+
+@pytest.mark.usefixtures("mock_valid_fvs_dll")
+def test_invoke_passes_inout_buffer_through_to_foreign_function():
+    fvs = FvsCore("/not/a/real/dir/FVSxx.so")
+    captured: list[ct.c_int] = []
+
+    def fvs_stub(itrncd):
+        captured.append(itrncd)
+        itrncd.value = 2
+
+    fvs._fvs = fvs_stub
+    itrncd = ct.c_int(0)
+    assert fvs._invoke("fvs", itrncd=itrncd) is None
+    assert captured == [itrncd]
+    assert itrncd.value == 2
+
+
+@pytest.mark.usefixtures("mock_valid_fvs_dll")
+def test_invoke_unknown_routine_raises_notimplementederror_with_name():
+    fvs = FvsCore("/not/a/real/dir/FVSxx.so")
+    with pytest.raises(
+        NotImplementedError,
+        match="'fvsNotARoutine' is not registered in FVS_ROUTINES",
+    ):
+        fvs._invoke("fvsNotARoutine")

--- a/fvs2py/tests/test_mixins.py
+++ b/fvs2py/tests/test_mixins.py
@@ -17,6 +17,7 @@ from fvs2py._mixins.control import ControlMixin
 from fvs2py._mixins.simulation import SimulationMixin
 from fvs2py._mixins.species import SpeciesMixin
 from fvs2py._mixins.stand import StandMixin
+from fvs2py._routines import FVS_ROUTINES
 from fvs2py.common import class_requires_fvs_library, no_fvs_library_required
 from fvs2py.constants import (
     MGMT_ID_COLUMN_NAME,
@@ -134,7 +135,9 @@ class _SimulationStub(SimulationMixin):
     The ``_fvs`` stub is a no-op so :meth:`SimulationMixin.run` can exercise
     its control flow without a real FVS library. :meth:`set_stop_point_codes`
     is stubbed to a no-op as well; tests that want to observe or override it
-    assign directly on the instance.
+    assign directly on the instance. ``_invoke`` mirrors
+    :meth:`fvs2py._core.FvsCore._invoke` so the mixin exercises the real
+    registry against the attribute-level stubs bound below.
     """
 
     def __init__(self, itrncd=0, exit_code=0, restart_code=0):
@@ -162,6 +165,9 @@ class _SimulationStub(SimulationMixin):
         self._fvsGetRestartCode = writer(restart_code)
         self._fvs = fvs
         self.set_stop_point_codes = lambda *_args: None
+
+    def _invoke(self, name, /, **kwargs):
+        return FVS_ROUTINES[name].call(getattr(self, f"_{name}"), **kwargs)
 
 
 def test_simulation_mixin_itrncd_reads_fvs_output():

--- a/fvs2py/tests/test_routines.py
+++ b/fvs2py/tests/test_routines.py
@@ -305,14 +305,9 @@ def test_call_out_param_in_kwargs_raises_typeerror():
 # ---------------------------------------------------------------------------
 # FVS_ROUTINES registry invariants
 #
-# The registry ships empty in this scaffolding commit; these invariants are
-# authored to guard entries contributed by later PRs (each iterates over
-# ``FVS_ROUTINES.items()`` and is vacuously true until populated).
+# Each iterates over ``FVS_ROUTINES.items()`` and thus applies to every
+# entry contributed by a mixin migration.
 # ---------------------------------------------------------------------------
-
-
-def test_registry_starts_empty_in_scaffolding_commit():
-    assert dict(FVS_ROUTINES) == {}
 
 
 def test_registry_entries_carry_their_mapping_key_as_name():


### PR DESCRIPTION
## Summary

First mixin migration onto the `FVS_ROUTINES` registry introduced by #23. Wires `FvsCore._invoke(name, /, **kwargs)` as the dispatch entry point for registry-described routines, registers the four routines `SimulationMixin` consumes, and flips the mixin off `call_out` and direct foreign-function calls onto the invoker. No user-visible behavior change — `exit_code`, `itrncd`, `restart_code`, and the `run`/`run_batch` loops behave identically.

Stacks on `routine-registry`; follow-up mixin migrations continue to stack on the same feature branch until the final PR retires `FVS_SIGNATURES` and `call_out`.

## What this PR adds

**`fvs2py/_routines.py` (+61 / -18)**

- Adds `ctypes as ct` to imports so registry entries can reference `ct.POINTER(ct.c_int)` declaratively.
- Populates `_RAW_ROUTINES` with four entries, each using declaration-order kwargs and the single-OUT / single-INOUT shapes that match their Fortran signatures:
  - `fvs` — one `Intent.INOUT` param (`itrncd`, `POINTER(c_int)`), `rc_param=None`. The caller-owned `_itrncd` buffer flows through unchanged and is read back via `fvsGetRtnCode`, matching the existing run-loop contract.
  - `fvsGetICCode`, `fvsGetRtnCode`, `fvsGetRestartCode` — each has a single `Intent.OUT` `c_int` param. `Routine.call` auto-allocates the buffer, calls the foreign function, and returns the unwrapped integer. These three routines are state-reporting, not error-reporting, so they carry `rc_param=None` / `rc_policy=None`.
- Refreshes the module docstring and the `FVS_ROUTINES` docstring to describe the "entries land alongside migrations" model now that the registry is non-empty.

**`fvs2py/_core.py` (+38)**

- `_invoke(name, /, **kwargs)` resolves `FVS_ROUTINES[name]`, fetches the bound foreign function at `self._<name>`, and delegates to `Routine.call` for argtype resolution, OUT auto-allocation, and rc-policy dispatch.
- Missing registry entries raise `NotImplementedError` (not `KeyError`) to signal "not migrated yet or misspelled" rather than leaking the dict-lookup mechanism. Covered by a dedicated test.

**`fvs2py/_mixins/simulation.py` (+29 / -22)**

- `exit_code`, `itrncd`, `restart_code` now call `self._invoke("fvsGetICCode" | "fvsGetRtnCode" | "fvsGetRestartCode")` instead of `call_out(self._fvsGet*Code)`.
- Both `_fvs` call sites (the inside-loop call in `_run_cycles` and the stand-complete flush in `run`) now call `self._invoke("fvs", itrncd=self._itrncd)`.
- Dropped the `call_out` import and the class-level `_fvs*: ct._FuncPointer` annotations the mixin no longer accesses directly; replaced with a single `_invoke: Callable[..., Any]` annotation so mypy sees the dispatcher contract.

**`fvs2py/_signatures.py` (+5 / -5)**

- Removed the four now-migrated routines (`fvs`, `fvsGetICCode`, `fvsGetRtnCode`, `fvsGetRestartCode`) from `FVS_SIGNATURES`. Added a docstring note that this mapping is being progressively retired in favor of `FVS_ROUTINES`.

**`fvs2py/tests/test_core.py` (+44)**

Three new tests exercising `FvsCore._invoke` end-to-end against the `mock_valid_fvs_dll` fixture:

- Single-OUT dispatch: `_invoke("fvsGetICCode")` returns the writer's value unwrapped.
- INOUT pass-through: `_invoke("fvs", itrncd=buf)` forwards the caller's `c_int` buffer by identity and reflects writes.
- Unknown routine: `_invoke("fvsNotARoutine")` raises `NotImplementedError` with the offending name in the message.

**`fvs2py/tests/test_mixins.py` (+5 / -1)**

- `_SimulationStub` gains an `_invoke` method that mirrors `FvsCore._invoke` (`FVS_ROUTINES[name].call(getattr(self, f"_{name}"), **kwargs)`). The existing attribute-level `_fvs*` stubs continue to work unchanged, so the suite exercises the real registry against plain Python callables.

**`fvs2py/tests/test_routines.py` (+0 / -6 net)**

- Dropped the scaffolding-era `test_registry_starts_empty_in_scaffolding_commit` — the premise no longer holds. The surviving `test_registry_entries_carry_their_mapping_key_as_name` now applies meaningfully to the four new entries and continues to cover everything added by later PRs.

## What this PR does NOT do

- Populate any routines outside of `SimulationMixin`'s consumption surface. `fvsDimSizes`, `fvsStandID`, `fvsSummary`, `fvsSetStoppointCodes`, `fvsSetCmdLine`, `fvsSpeciesCode`, `fvsSpeciesAttr`, and `fvsTreeAttr` remain unmigrated and unchanged.
- Remove `call_out` from `fvs2py/common.py`. Still imported and used by `ControlMixin`, `StandMixin`, `SpeciesMixin`; its removal comes with the final retirement PR.
- Delete `fvs2py/_signatures.py`. Five entries still active (covering the routines not yet migrated); the file goes away in the final PR.

## Test plan

- [x] `pytest fvs2py/tests/` (excluding `test_fvs_build.py`) — 171 tests pass locally.
- [x] `ruff check` clean on all touched files.
- [x] `mypy` clean via pre-commit hook.
- [x] `pytest fvs2py/tests/test_fvs_build.py` with a real FVS shared library — confirms `run` / `run_batch` behave identically against the live library, since the mixin's public surface has not changed.
- [x] Manual smoke: load a keyfile, call `run`, inspect `itrncd`, `exit_code`, `restart_code` — each returns the same values as before.

## Follow-up PRs (continuing to stack on `routine-registry`)

1. Migrate `StandMixin` (`fvsDimSizes`, `fvsStandID`, `fvsSummary`) — kills the inline `argtypes` assignment on `fvsSummary` using an `ndptr_intc` factory.
2. Migrate `SpeciesMixin` (`fvsSpeciesAttr`, `fvsSpeciesCode`) onto `attr_accessor_policy`.
3. Migrate `ControlMixin` (`fvsSetCmdLine`, `fvsSetStoppointCodes`).
4. Add `TreesMixin` with `fvsTreeAttr` using the registry from day one.
5. Delete `fvs2py/_signatures.py` and `call_out` from `fvs2py/common.py`.

Merge `routine-registry` to `main` after step 5.