### PR TITLE
migrates StandMixin to registry of FVS_ROUTINES

### DIFF
--- a/fvs2py/_mixins/stand.py
+++ b/fvs2py/_mixins/stand.py
@@ -3,23 +3,18 @@
 from __future__ import annotations
 
 import ctypes as ct
+from collections.abc import Callable
+from typing import Any
 
 import numpy as np
 import pandas as pd
 
-from fvs2py.common import call_out, fvs_property
+from fvs2py.common import fvs_property
 from fvs2py.constants import (
     MGMT_ID_COLUMN_NAME,
     STAND_CN_COLUMN_NAME,
     STAND_ID_COLUMN_NAME,
-    STR_C_CONTIGUOUS,
-    STR_MAXCYCLES,
-    STR_MAXPLOTS,
-    STR_MAXSPECIES,
-    STR_MAXTREES,
     STR_NCYCLES,
-    STR_NPLOTS,
-    STR_NTREES,
     SUMMARY_COLS,
 )
 
@@ -27,17 +22,13 @@ from fvs2py.constants import (
 class StandMixin:
     """Expose stand-level FVS outputs: dimensions, identifiers, summary table.
 
-    Assumes the composed class provides the foreign-function attributes
-    ``_fvsDimSizes``, ``_fvsStandID``, ``_fvsSummary`` (resolved by
-    :class:`fvs2py._core.FvsCore`) and the Python-side buffers ``_stand_id``,
-    ``_stand_cn``, ``_mgmt_id`` (initialized by
-    ``FVS._initialize_attributes``). ``keyfile`` and ``stop_point_code``
-    come from :class:`ControlMixin`.
+    Assumes the composed class provides :meth:`FvsCore._invoke` for registry
+    dispatch and the Python-side buffers ``_stand_id``, ``_stand_cn``,
+    ``_mgmt_id`` (initialized by ``FVS._initialize_attributes``). ``keyfile``
+    and ``stop_point_code`` come from :class:`ControlMixin`.
     """
 
-    _fvsDimSizes: ct._FuncPointer
-    _fvsStandID: ct._FuncPointer
-    _fvsSummary: ct._FuncPointer
+    _invoke: Callable[..., Any]
     _stand_id: ct.Array[ct.c_char]
     _stand_cn: ct.Array[ct.c_char]
     _mgmt_id: ct.Array[ct.c_char]
@@ -47,18 +38,7 @@ class StandMixin:
     @fvs_property
     def dims(self) -> dict:
         """Return the max dimensions of important FVS data storage."""
-        ntrees, ncycles, nplots, maxtrees, maxspecies, maxplots, maxcycles = (
-            call_out(self._fvsDimSizes, out_types=(ct.c_int,) * 7)
-        )
-        return {
-            STR_NTREES: ntrees,
-            STR_NCYCLES: ncycles,
-            STR_NPLOTS: nplots,
-            STR_MAXTREES: maxtrees,
-            STR_MAXSPECIES: maxspecies,
-            STR_MAXPLOTS: maxplots,
-            STR_MAXCYCLES: maxcycles,
-        }
+        return self._invoke("fvsDimSizes")
 
     @fvs_property
     def stand_ids(self) -> dict:
@@ -76,13 +56,14 @@ class StandMixin:
             msg = "No inventory data loaded yet. Call `run` method."
             raise RuntimeError(msg)
 
-        self._fvsStandID(
-            self._stand_id,
-            self._stand_cn,
-            self._mgmt_id,
-            ct.c_int(0),
-            ct.c_int(0),
-            ct.c_int(0),
+        self._invoke(
+            "fvsStandID",
+            stand_id=self._stand_id,
+            stand_cn=self._stand_cn,
+            mgmt_id=self._mgmt_id,
+            stand_id_len=ct.c_int(0),
+            stand_cn_len=ct.c_int(0),
+            mgmt_id_len=ct.c_int(0),
         )
 
         return {
@@ -98,16 +79,6 @@ class StandMixin:
         The returned dataframe omits cycles that have not yet been initiated, which are
         identifiable where all values in that row are zero.
         """
-        self._fvsSummary.argtypes = [
-            np.ctypeslib.ndpointer(np.intc, flags=STR_C_CONTIGUOUS),  # type: ignore[arg-type]
-            ct.POINTER(ct.c_int),
-            ct.POINTER(ct.c_int),
-            ct.POINTER(ct.c_int),
-            ct.POINTER(ct.c_int),
-            ct.POINTER(ct.c_int),
-        ]
-        self._fvsSummary.restype = None
-
         dims = self.dims
         if dims[STR_NCYCLES] == 0:
             return None
@@ -116,13 +87,13 @@ class StandMixin:
             shape=(dims[STR_NCYCLES] + 1, len(SUMMARY_COLS)),
         )
         for i in range(dims[STR_NCYCLES] + 1):
-            self._fvsSummary(
-                summary[i],
-                ct.c_int(i + 1),  # icycle
-                ct.c_int(dims[STR_NCYCLES]),  # ncycles
-                ct.c_int(0),  # maxrow
-                ct.c_int(0),  # maxcol
-                ct.c_int(0),  # rtncode
+            self._invoke(
+                "fvsSummary",
+                summary=summary[i],
+                icycle=ct.c_int(i + 1),
+                ncycles=ct.c_int(dims[STR_NCYCLES]),
+                maxrow=ct.c_int(0),
+                maxcol=ct.c_int(0),
             )
 
         empty_years = (summary == 0).all(axis=1)

--- a/fvs2py/_routines.py
+++ b/fvs2py/_routines.py
@@ -24,7 +24,16 @@ from typing import Any
 
 import numpy as np
 
-from fvs2py.constants import STR_C_CONTIGUOUS
+from fvs2py.constants import (
+    STR_C_CONTIGUOUS,
+    STR_MAXCYCLES,
+    STR_MAXPLOTS,
+    STR_MAXSPECIES,
+    STR_MAXTREES,
+    STR_NCYCLES,
+    STR_NPLOTS,
+    STR_NTREES,
+)
 from fvs2py.enums import FvsAttrReturnCode
 
 
@@ -332,6 +341,65 @@ _RAW_ROUTINES: dict[str, Routine] = {
             ),
         ),
         rc_param=None,
+    ),
+    "fvsDimSizes": Routine(
+        params=(
+            Param(
+                name=STR_NTREES, ctype=ct.POINTER(ct.c_int), intent=Intent.OUT
+            ),
+            Param(
+                name=STR_NCYCLES, ctype=ct.POINTER(ct.c_int), intent=Intent.OUT
+            ),
+            Param(
+                name=STR_NPLOTS, ctype=ct.POINTER(ct.c_int), intent=Intent.OUT
+            ),
+            Param(
+                name=STR_MAXTREES, ctype=ct.POINTER(ct.c_int), intent=Intent.OUT
+            ),
+            Param(
+                name=STR_MAXSPECIES,
+                ctype=ct.POINTER(ct.c_int),
+                intent=Intent.OUT,
+            ),
+            Param(
+                name=STR_MAXPLOTS, ctype=ct.POINTER(ct.c_int), intent=Intent.OUT
+            ),
+            Param(
+                name=STR_MAXCYCLES,
+                ctype=ct.POINTER(ct.c_int),
+                intent=Intent.OUT,
+            ),
+        ),
+        rc_param=None,
+    ),
+    "fvsStandID": Routine(
+        params=(
+            Param(name="stand_id", ctype=ct.c_char_p, intent=Intent.INOUT),
+            Param(name="stand_cn", ctype=ct.c_char_p, intent=Intent.INOUT),
+            Param(name="mgmt_id", ctype=ct.c_char_p, intent=Intent.INOUT),
+            Param(name="stand_id_len", ctype=ct.POINTER(ct.c_int)),
+            Param(name="stand_cn_len", ctype=ct.POINTER(ct.c_int)),
+            Param(name="mgmt_id_len", ctype=ct.POINTER(ct.c_int)),
+        ),
+        rc_param=None,
+    ),
+    "fvsSummary": Routine(
+        params=(
+            Param(
+                name="summary",
+                ctype=np.ctypeslib.ndpointer(np.intc, flags=STR_C_CONTIGUOUS),
+                intent=Intent.INOUT,
+            ),
+            Param(name="icycle", ctype=ct.POINTER(ct.c_int)),
+            Param(name="ncycles", ctype=ct.POINTER(ct.c_int)),
+            Param(name="maxrow", ctype=ct.POINTER(ct.c_int)),
+            Param(name="maxcol", ctype=ct.POINTER(ct.c_int)),
+            Param(
+                name="rtncode",
+                ctype=ct.POINTER(ct.c_int),
+                intent=Intent.OUT,
+            ),
+        ),
     ),
 }
 

--- a/fvs2py/_signatures.py
+++ b/fvs2py/_signatures.py
@@ -39,13 +39,9 @@ class Signature(NamedTuple):
 
 FVS_SIGNATURES: Mapping[str, Signature] = MappingProxyType(
     {
-        "fvsDimSizes": Signature((ct.POINTER(ct.c_int),) * 7),
         "fvsSetStoppointCodes": Signature((ct.POINTER(ct.c_int),) * 2),
         "fvsSetCmdLine": Signature(
             (ct.c_char_p, ct.POINTER(ct.c_int), ct.POINTER(ct.c_int)),
-        ),
-        "fvsStandID": Signature(
-            (ct.c_char_p,) * 3 + (ct.POINTER(ct.c_int),) * 3,
         ),
         "fvsSpeciesCode": Signature(
             (ct.c_char_p,) * 3 + (ct.POINTER(ct.c_int),) * 5,

--- a/fvs2py/tests/test_mixins.py
+++ b/fvs2py/tests/test_mixins.py
@@ -83,6 +83,9 @@ class _StandStub(StandMixin, ControlMixin):
         self._fvsDimSizes = fvs_dim_sizes
         self._fvsStandID = fvs_stand_id
 
+    def _invoke(self, name, /, **kwargs):
+        return FVS_ROUTINES[name].call(getattr(self, f"_{name}"), **kwargs)
+
 
 def test_stand_mixin_dims_returns_named_dict():
     stub = _StandStub()


### PR DESCRIPTION
## Summary

Migrates `StandMixin` to dispatch through `FvsCore._invoke` and the `FVS_ROUTINES` registry. Retires the last runtime `argtypes = [...]` reassignment in the mixin layer (on `fvsSummary`), collapses `StandMixin.dims` to a one-liner, and removes the corresponding `fvsDimSizes`/`fvsStandID` entries from the legacy `FVS_SIGNATURES` map.

## What's migrated

Three routines land in `FVS_ROUTINES` alongside the simulation quartet that shipped previously:

- `fvsDimSizes` — 7 `Intent.OUT` `POINTER(c_int)` params named with the existing `STR_NTREES` / `STR_NCYCLES` / ... constants. The registry's multi-OUT return already yields `{STR_NTREES: n, STR_NCYCLES: n, ...}`, so `StandMixin.dims` is now a literal `return self._invoke("fvsDimSizes")`.
- `fvsStandID` — 3 `Intent.INOUT` `c_char_p` caller-owned string buffers plus 3 `Intent.IN` `POINTER(c_int)` length slots (the hidden-Fortran convention args the call site passes as `c_int(0)`). `rc_param=None`; the mixin still reads `.value` off its own buffers after the call.
- `fvsSummary` — static-shape `np.ctypeslib.ndpointer(np.intc, flags=C_CONTIGUOUS)` as an `Intent.INOUT` row buffer, four `Intent.IN` `POINTER(c_int)` params, and an `Intent.OUT` `rtncode`. `rc_param="rtncode"` with `rc_policy=None` so the return code is auto-allocated and suppressed from the return (matching the pre-migration "pass `c_int(0)` and ignore it" behavior).

## Call-site changes

- `StandMixin.dims` returns the registry dict directly — no more tuple-unpack + dict-rebuild.
- `StandMixin.stand_ids` swaps the positional `self._fvsStandID(...)` call for `self._invoke("fvsStandID", stand_id=..., stand_cn=..., mgmt_id=..., stand_id_len=c_int(0), ...)`; post-call buffer decoding is unchanged.
- `StandMixin.summary` drops the 9-line inline `argtypes` / `restype` block and calls `self._invoke("fvsSummary", summary=summary[i], icycle=..., ncycles=..., maxrow=..., maxcol=...)` per cycle. Empty-cycle filtering and DataFrame construction are untouched.
- Class-level `_fvsDimSizes` / `_fvsStandID` / `_fvsSummary` annotations replaced with `_invoke: Callable[..., Any]`. `call_out` and `STR_C_CONTIGUOUS` imports removed from the mixin.

## Legacy registry shrink

`FVS_SIGNATURES` loses `fvsDimSizes` and `fvsStandID`. What remains in the legacy map is exactly the set of routines still owned by un-migrated mixins (`fvsSetStoppointCodes`, `fvsSetCmdLine`, `fvsSpeciesCode`).

## Tests

- `_StandStub` in `tests/test_mixins.py` gains the same `_invoke` shim `_SimulationStub` uses (`FVS_ROUTINES[name].call(getattr(self, f"_{name}"), **kwargs)`), so the existing `dims` / `stand_ids` tests now exercise the full registry path against the Python-callable stubs.
- The three existing stand tests (`test_stand_mixin_dims_returns_named_dict`, both `stand_ids` guard tests, `test_stand_mixin_stand_ids_returns_decoded_values`) pass unchanged — stub signatures already accepted the positional OUT pointers and c_char_p buffers that `Routine.call` passes through.
- Full suite: 193 passed.

## Follow-up PRs

Still targeting the same feature branch, roughly in order of payoff:

1. `ControlMixin` (`fvsSetStoppointCodes`, `fvsSetCmdLine`) — retires two more static `FVS_SIGNATURES` entries.
2. `SpeciesMixin` (`fvsSpeciesCode`, `fvsSpeciesAttr`) — first use of `attr_accessor_policy` and of `ndptr_f64` / `ndptr_intc` dynamic factories in an actual migration.
3. `TreesMixin` (`fvsTreeAttr`) — the original motivating case; depends on the `ntrees` runtime dimension.