### PR TITLE
migrates ControlMixin to registry of FVS_ROUTINES

### DIFF
--- a/fvs2py/_mixins/control.py
+++ b/fvs2py/_mixins/control.py
@@ -8,6 +8,7 @@ import os
 import warnings
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 from fvs2py.common import fvs_property
 from fvs2py.enums import FvsItrnCode, FvsStopPointCode
@@ -17,16 +18,14 @@ from fvs2py.keyfile import validate_single_stand
 class ControlMixin:
     """Expose keyfile loading and stop-point configuration.
 
-    Assumes the composed class provides ``_fvsSetCmdLine`` and
-    ``_fvsSetStoppointCodes`` (resolved by :class:`fvs2py._core.FvsCore`),
-    the ``_itrncd`` buffer, and the ``_stop_point_code``/``_stop_point_year``
-    slots initialized by ``FVS._initialize_attributes``. :meth:`run` on
-    :class:`SimulationMixin` is expected to call into
-    :meth:`set_stop_point_codes`.
+    Assumes the composed class provides :meth:`FvsCore._invoke` for registry
+    dispatch, the ``_itrncd`` buffer, and the
+    ``_stop_point_code``/``_stop_point_year`` slots initialized by
+    ``FVS._initialize_attributes``. :meth:`run` on :class:`SimulationMixin`
+    is expected to call into :meth:`set_stop_point_codes`.
     """
 
-    _fvsSetCmdLine: ct._FuncPointer
-    _fvsSetStoppointCodes: ct._FuncPointer
+    _invoke: Callable[..., Any]
     _itrncd: ct.c_int
     _stop_point_code: ct.c_int | None
     _stop_point_year: ct.c_int | None
@@ -149,7 +148,12 @@ class ControlMixin:
         cmdline = f"--keywordfile={self.keyfile_path}"
         nch = len(cmdline)
 
-        self._fvsSetCmdLine(cmdline.encode(), ct.c_int(nch), self._itrncd)
+        self._invoke(
+            "fvsSetCmdLine",
+            cmdline=cmdline.encode(),
+            nch=ct.c_int(nch),
+            itrncd=self._itrncd,
+        )
         logging.debug(f"Return code updated to {self.itrncd}")
 
     def set_stop_point_codes(
@@ -204,4 +208,8 @@ class ControlMixin:
         elif self._stop_point_year is None:
             self._stop_point_year = ct.c_int(0)
 
-        self._fvsSetStoppointCodes(self._stop_point_code, self._stop_point_year)
+        self._invoke(
+            "fvsSetStoppointCodes",
+            stop_point_code=self._stop_point_code,
+            stop_point_year=self._stop_point_year,
+        )

--- a/fvs2py/_routines.py
+++ b/fvs2py/_routines.py
@@ -372,6 +372,25 @@ _RAW_ROUTINES: dict[str, Routine] = {
         ),
         rc_param=None,
     ),
+    "fvsSetCmdLine": Routine(
+        params=(
+            Param(name="cmdline", ctype=ct.c_char_p),
+            Param(name="nch", ctype=ct.POINTER(ct.c_int)),
+            Param(
+                name="itrncd",
+                ctype=ct.POINTER(ct.c_int),
+                intent=Intent.INOUT,
+            ),
+        ),
+        rc_param=None,
+    ),
+    "fvsSetStoppointCodes": Routine(
+        params=(
+            Param(name="stop_point_code", ctype=ct.POINTER(ct.c_int)),
+            Param(name="stop_point_year", ctype=ct.POINTER(ct.c_int)),
+        ),
+        rc_param=None,
+    ),
     "fvsStandID": Routine(
         params=(
             Param(name="stand_id", ctype=ct.c_char_p, intent=Intent.INOUT),

--- a/fvs2py/_signatures.py
+++ b/fvs2py/_signatures.py
@@ -39,10 +39,6 @@ class Signature(NamedTuple):
 
 FVS_SIGNATURES: Mapping[str, Signature] = MappingProxyType(
     {
-        "fvsSetStoppointCodes": Signature((ct.POINTER(ct.c_int),) * 2),
-        "fvsSetCmdLine": Signature(
-            (ct.c_char_p, ct.POINTER(ct.c_int), ct.POINTER(ct.c_int)),
-        ),
         "fvsSpeciesCode": Signature(
             (ct.c_char_p,) * 3 + (ct.POINTER(ct.c_int),) * 5,
         ),

--- a/fvs2py/tests/test_mixins.py
+++ b/fvs2py/tests/test_mixins.py
@@ -297,6 +297,9 @@ class _ControlStub(ControlMixin):
         self._stop_point_year = None
         self._fvsSetStoppointCodes = lambda *_args: None
 
+    def _invoke(self, name, /, **kwargs):
+        return FVS_ROUTINES[name].call(getattr(self, f"_{name}"), **kwargs)
+
 
 def test_control_mixin_stop_point_code_returns_none_when_unset():
     stub = _ControlStub()


### PR DESCRIPTION
## Summary

Migrates `ControlMixin` to dispatch through `FvsCore._invoke` and the `FVS_ROUTINES` registry. Empties `FVS_SIGNATURES` of every control-path routine; the only entry still in the legacy map is `fvsSpeciesCode`, owned by the not-yet-migrated `SpeciesMixin`.

## What's migrated

Two routines land in `FVS_ROUTINES`:

- `fvsSetCmdLine` — `cmdline` as `Intent.IN` `c_char_p` (caller passes encoded bytes), `nch` as `Intent.IN` `POINTER(c_int)`, and `itrncd` as `Intent.INOUT` `POINTER(c_int)` (the simulation-status buffer the FVS entry point writes into in place). `rc_param=None`; `itrncd` is a simulation status, not an attr-accessor return code, so no policy is attached.
- `fvsSetStoppointCodes` — `stop_point_code` and `stop_point_year`, both `Intent.IN` `POINTER(c_int)`. No OUT params, no rc.

## Call-site changes

- `ControlMixin.load_keyfile` now calls `self._invoke("fvsSetCmdLine", cmdline=cmdline.encode(), nch=ct.c_int(nch), itrncd=self._itrncd)` in place of the direct `self._fvsSetCmdLine(...)` invocation. The surrounding keyfile-validation, reload-on-restart, and `keyfile_path` bookkeeping are untouched.
- `ControlMixin.set_stop_point_codes` now calls `self._invoke("fvsSetStoppointCodes", stop_point_code=self._stop_point_code, stop_point_year=self._stop_point_year)` after the existing validation + buffer-allocation block.
- Class-level `_fvsSetCmdLine` / `_fvsSetStoppointCodes` annotations replaced with `_invoke: Callable[..., Any]`; added `from typing import Any`. Docstring updated to reflect reliance on `FvsCore._invoke`.

## Legacy registry shrink

`FVS_SIGNATURES` now contains exactly one entry: `fvsSpeciesCode`. That will disappear when `SpeciesMixin` migrates in the next PR, at which point `FVS_SIGNATURES` itself can be deleted.

## Tests

- `_ControlStub` in `tests/test_mixins.py` gains the same `_invoke` shim the other stubs use (`FVS_ROUTINES[name].call(getattr(self, f"_{name}"), **kwargs)`). The existing `_fvsSetStoppointCodes = lambda *_args: None` stub still satisfies the new dispatch path because `Routine.call` hands the two `POINTER(c_int)` values to the callable positionally, which the lambda absorbs via `*_args`.
- All existing ControlMixin tests (stop-point-code/year getters and setters, validation guards, set-without-code failure) pass unchanged, since the registry call happens downstream of every guard they exercise.
- Full suite: 193 passed.

## Follow-up PRs

Still on the same feature branch:

1. `SpeciesMixin` — `fvsSpeciesCode` (last static-signature holdout; 3× `c_char_p` + 5× `POINTER(c_int)` with two hidden-Fortran length slots) and `fvsSpeciesAttr` (first real migration to land `attr_accessor_policy` plus the `ndptr_f64` / `ndptr_intc` dynamic factories, keyed off `dims[STR_MAXSPECIES]`). Once this merges, `FVS_SIGNATURES` is fully retired and can be deleted from `fvs2py/_signatures.py`.
2. `TreesMixin` — `fvsTreeAttr`, the original motivating case; depends on the `ntrees` runtime dimension and exercises both `attr_accessor_policy` and `ndptr_f64` / `ndptr_intc` end-to-end.