### PR TITLE
Adds TreesMixin

### DIFF
--- a/fvs2py/_base.py
+++ b/fvs2py/_base.py
@@ -11,20 +11,29 @@ from fvs2py._mixins import (
     SimulationMixin,
     SpeciesMixin,
     StandMixin,
+    TreesMixin,
 )
 from fvs2py.common import class_requires_fvs_library
-from fvs2py.constants import SPECIES_ATTRS
+from fvs2py.constants import SPECIES_ATTRS, TREE_ATTRS
 from fvs2py.enums import FvsSimulationState
 
 
 @class_requires_fvs_library
-class FVS(SpeciesMixin, StandMixin, SimulationMixin, ControlMixin, FvsCore):
+class FVS(
+    TreesMixin,
+    SpeciesMixin,
+    StandMixin,
+    SimulationMixin,
+    ControlMixin,
+    FvsCore,
+):
     """Main class for interacting with FVS at runtime.
 
-    Public behavior is contributed by the four mixins
-    (:class:`SpeciesMixin`, :class:`StandMixin`, :class:`SimulationMixin`,
-    :class:`ControlMixin`); this class just initializes the Python-side
-    buffers they rely on and wires the library-reload hook.
+    Public behavior is contributed by the five mixins
+    (:class:`TreesMixin`, :class:`SpeciesMixin`, :class:`StandMixin`,
+    :class:`SimulationMixin`, :class:`ControlMixin`); this class just
+    initializes the Python-side buffers they rely on and wires the
+    library-reload hook.
     """
 
     def __init__(self, lib_path: str | os.PathLike) -> None:
@@ -61,6 +70,8 @@ class FVS(SpeciesMixin, StandMixin, SimulationMixin, ControlMixin, FvsCore):
         self._state = FvsSimulationState.IDLE
         self._stop_point_code = None
         self._stop_point_year = None
+        self._tree_attrs = TREE_ATTRS
+        self._trees = dict.fromkeys(TREE_ATTRS)
 
     def _reload_fvs(self) -> None:
         """Unload the current library, load a fresh one, and reset buffers."""

--- a/fvs2py/_mixins/__init__.py
+++ b/fvs2py/_mixins/__init__.py
@@ -10,10 +10,12 @@ from fvs2py._mixins.control import ControlMixin
 from fvs2py._mixins.simulation import SimulationMixin
 from fvs2py._mixins.species import SpeciesMixin
 from fvs2py._mixins.stand import StandMixin
+from fvs2py._mixins.trees import TreesMixin
 
 __all__ = [
     "ControlMixin",
     "SimulationMixin",
     "SpeciesMixin",
     "StandMixin",
+    "TreesMixin",
 ]

--- a/fvs2py/_mixins/trees.py
+++ b/fvs2py/_mixins/trees.py
@@ -1,0 +1,163 @@
+"""Tree-level attribute access and bulk tree insertion mixin."""
+
+from __future__ import annotations
+
+import ctypes as ct
+import warnings
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+
+from fvs2py.common import fvs_property
+from fvs2py.constants import (
+    ADD_TREES_COLS,
+    STR_MAXTREES,
+    STR_NPLOTS,
+    STR_NTREES,
+)
+from fvs2py.enums import FvsAttributeAccessor
+
+
+class TreesMixin:
+    """Expose per-tree attribute access and bulk tree insertion.
+
+    Assumes the composed class provides :meth:`FvsCore._invoke` for registry
+    dispatch, ``self.dims`` from :class:`StandMixin`, ``self.species_codes``
+    from :class:`SpeciesMixin`, and the ``_tree_attrs`` / ``_trees`` buffers
+    seeded by ``FVS._initialize_attributes``.
+    """
+
+    _invoke: Callable[..., Any]
+    _tree_attrs: tuple[str, ...]
+    _trees: dict[str, npt.NDArray[np.float64] | None]
+    dims: dict
+    species_codes: pd.DataFrame
+
+    @fvs_property
+    def trees(self) -> pd.DataFrame | None:
+        """Returns a dataframe of trees currently in FVS."""
+        if self.dims[STR_NTREES] == 0:
+            warnings.warn("No trees in FVS yet.")
+            return None
+
+        for attr in self._tree_attrs:
+            _ = self.get_tree_attr(attr)
+
+        return pd.DataFrame(self._trees, copy=False)
+
+    def get_tree_attr(self, attr: str) -> npt.NDArray[np.float64]:
+        """Gets a single attribute for existing trees.
+
+        Args:
+            attr (str): name of tree attribute to fetch
+
+        Returns:
+            array with values of requested attribute for all trees
+        """
+        self._tree_attr(attr, FvsAttributeAccessor.GET)
+        return self._trees[attr]
+
+    def set_tree_attr(self, attr: str, arr: npt.NDArray[np.float64]) -> None:
+        """Sets a single attribute for all existing trees.
+
+        Args:
+            attr (str): name of tree attribute to set
+            arr (npt.NDArray[np.float64]): values to set tree attribute to
+        """
+        return self._tree_attr(attr, FvsAttributeAccessor.SET, arr)
+
+    def _tree_attr(
+        self,
+        attr: str,
+        action: FvsAttributeAccessor,
+        arr: npt.NDArray[np.float64] | None = None,
+    ) -> None:
+        """Get or set a single attribute for existing trees.
+
+        Args:
+            attr (str): attribute to set or get
+            action (FvsAttributeAccessor): 'set' or 'get'
+            arr (optional, npt.NDArray[np.float64]): array of values to set
+        """
+        if attr not in self._tree_attrs:
+            self._trees[attr] = None
+
+        ntrees = self.dims[STR_NTREES]
+
+        if action == FvsAttributeAccessor.GET:
+            self._trees[attr] = np.empty(dtype=np.float64, shape=(ntrees,))
+            if ntrees == 0:
+                warnings.warn("No trees in FVS yet.")
+        elif action == FvsAttributeAccessor.SET:
+            if arr is None:
+                msg = "Must provide `arr` if `action` is 'set'"
+                raise TypeError(msg)
+            if arr.shape != (ntrees,):
+                msg = f"`arr` must be same shape as `ntrees` ({ntrees},)"
+                raise ValueError(msg)
+            self._trees[attr] = arr
+
+        self._invoke(
+            "fvsTreeAttr",
+            attr_name=ct.c_char_p(attr.encode()),
+            nch=ct.c_int(len(attr)),
+            action=ct.c_char_p(action.encode()),
+            ntrees=ct.c_int(ntrees),
+            arr=self._trees[attr],
+        )
+
+    def add_trees(self, tree_df: pd.DataFrame) -> None:
+        """Adds trees to an existing simulation.
+
+        Args:
+            tree_df (pd.DataFrame): trees to add. Must contain every column
+                listed in :data:`fvs2py.constants.ADD_TREES_COLS`
+                (``dbh``, ``species``, ``ht``, ``cratio``, ``plot``, ``tpa``),
+                with non-null float-coercible values for every row. Extra
+                columns are ignored.
+        """
+        missing = tuple(c for c in ADD_TREES_COLS if c not in tree_df.columns)
+        if missing:
+            msg = (
+                f"tree_df is missing required column(s) {list(missing)}; "
+                f"expected all of {list(ADD_TREES_COLS)}"
+            )
+            raise ValueError(msg)
+
+        ntrees = len(tree_df)
+        trees = tree_df[list(ADD_TREES_COLS)].astype(np.float64)
+        if trees.isna().any().any():
+            msg = "No null values allowed in trees to add."
+            raise ValueError(msg)
+
+        dims = self.dims
+        if dims[STR_MAXTREES] < dims[STR_NTREES] + ntrees:
+            room = dims[STR_MAXTREES] - dims[STR_NTREES]
+            msg = f"Only room for {room} new trees but {ntrees} supplied."
+            raise ValueError(msg)
+
+        if dims[STR_NPLOTS] == 0:
+            msg = "No inventory plots loaded yet."
+            raise RuntimeError(msg)
+
+        if not trees["plot"].isin(range(1, dims[STR_NPLOTS] + 1)).all():
+            msg = "Plot codes must be within range already defined."
+            raise ValueError(msg)
+
+        if not trees["species"].isin(self.species_codes["fvs_index"]).all():
+            msg = "Unrecognized species code(s). Use FVS Species Index."
+            raise ValueError(msg)
+
+        self._invoke(
+            "fvsAddTrees",
+            dbh=trees["dbh"].values,
+            species=trees["species"].values,
+            ht=trees["ht"].values,
+            cratio=trees["cratio"].values,
+            plot=trees["plot"].values,
+            tpa=trees["tpa"].values,
+            ntrees=ct.c_int(ntrees),
+        )

--- a/fvs2py/_routines.py
+++ b/fvs2py/_routines.py
@@ -294,13 +294,36 @@ def species_code_policy(rc: int) -> None:
     raise RuntimeError(msg)
 
 
+def add_trees_policy(rc: int) -> None:
+    """Dispatch :class:`fvsAddTrees`'s documented return-code contract.
+
+    The FVS API documents two codes for ``fvsAddTrees``: ``0`` = OK and
+    ``1`` = there was not enough room to store the new trees. The latter
+    is surfaced as :class:`ValueError` so callers can catch it alongside
+    the mixin's own capacity pre-check. Any other value is treated as an
+    unexpected return code and raised as :class:`RuntimeError` so callers
+    do not silently proceed.
+    """
+    if rc == 0:
+        return
+    if rc == 1:
+        msg = "Not enough room to store the new trees"
+        raise ValueError(msg)
+    msg = f"unrecognized fvsAddTrees return code: {rc}"
+    raise RuntimeError(msg)
+
+
 def attr_accessor_policy(rc: int) -> None:
     """Raise if ``rc`` is not :attr:`FvsAttrReturnCode.OK`.
 
     Consumed by the ``rc_policy`` field on :class:`Routine` entries whose
     return codes follow the canonical attr-accessor convention shared by
-    ``fvsSpeciesAttr``, ``fvsTreeAttr``, and similar routines. For codes
-    outside the known set, a generic :class:`RuntimeError` is raised.
+    ``fvsSpeciesAttr``, ``fvsTreeAttr``, and similar routines.
+    :attr:`FvsAttrReturnCode.NAME_NOT_FOUND` surfaces as :class:`NameError`
+    (a caller-supplied attribute name that FVS does not recognize); the
+    remaining documented codes surface as :class:`RuntimeError` with the
+    enum's canned message. Codes outside the known set also become a
+    :class:`RuntimeError`, surfaced via the generic "unrecognized" message.
     """
     if rc == FvsAttrReturnCode.OK:
         return
@@ -455,6 +478,66 @@ _RAW_ROUTINES: dict[str, Routine] = {
             ),
         ),
         rc_policy=attr_accessor_policy,
+    ),
+    "fvsTreeAttr": Routine(
+        params=(
+            Param(name="attr_name", ctype=ct.c_char_p),
+            Param(name="nch", ctype=ct.POINTER(ct.c_int)),
+            Param(name="action", ctype=ct.c_char_p),
+            Param(name=STR_NTREES, ctype=ct.POINTER(ct.c_int)),
+            Param(
+                name="arr",
+                ctype=ndptr_f64(STR_NTREES),
+                intent=Intent.INOUT,
+            ),
+            Param(
+                name="rtncode",
+                ctype=ct.POINTER(ct.c_int),
+                intent=Intent.OUT,
+            ),
+        ),
+        rc_policy=attr_accessor_policy,
+    ),
+    "fvsAddTrees": Routine(
+        params=(
+            Param(
+                name="dbh",
+                ctype=ndptr_f64(STR_NTREES),
+                intent=Intent.INOUT,
+            ),
+            Param(
+                name="species",
+                ctype=ndptr_f64(STR_NTREES),
+                intent=Intent.INOUT,
+            ),
+            Param(
+                name="ht",
+                ctype=ndptr_f64(STR_NTREES),
+                intent=Intent.INOUT,
+            ),
+            Param(
+                name="cratio",
+                ctype=ndptr_f64(STR_NTREES),
+                intent=Intent.INOUT,
+            ),
+            Param(
+                name="plot",
+                ctype=ndptr_f64(STR_NTREES),
+                intent=Intent.INOUT,
+            ),
+            Param(
+                name="tpa",
+                ctype=ndptr_f64(STR_NTREES),
+                intent=Intent.INOUT,
+            ),
+            Param(name=STR_NTREES, ctype=ct.POINTER(ct.c_int)),
+            Param(
+                name="rtncode",
+                ctype=ct.POINTER(ct.c_int),
+                intent=Intent.OUT,
+            ),
+        ),
+        rc_policy=add_trees_policy,
     ),
     "fvsSummary": Routine(
         params=(

--- a/fvs2py/constants.py
+++ b/fvs2py/constants.py
@@ -43,6 +43,44 @@ SPECIES_COLUMN_NAMES = [
     SPECIES_FIA_COLUMN_NAME,
     SPECIES_PLANTS_COLUMN_NAME,
 ]
+ADD_TREES_COLS = (
+    "dbh",
+    "species",
+    "ht",
+    "cratio",
+    "plot",
+    "tpa",
+)
+
+TREE_ATTRS = (
+    "age",
+    "bdft",
+    "cratio",
+    "crownwt0",
+    "crownwt1",
+    "crownwt2",
+    "crownwt3",
+    "crownwt4",
+    "crownwt5",
+    "crwdth",
+    "dbh",
+    "defect",
+    "dg",
+    "ht",
+    "htg",
+    "id",
+    "mcuft",
+    "mgmtcd",
+    "mort",
+    "plot",
+    "plotsize",
+    "ptbalt",
+    "special",
+    "species",
+    "tcuft",
+    "tpa",
+)
+
 SPECIES_ATTRS = (
     "spccf",
     "spsdi",

--- a/fvs2py/enums.py
+++ b/fvs2py/enums.py
@@ -104,16 +104,20 @@ class FvsStopPointCode(IntEnum):
 class FvsAttrReturnCode(IntEnum):
     """Return-code values reported by attribute-accessor FVS routines.
 
-    Produced by ``fvsSpeciesAttr`` (and sibling routines with the same
-    convention) in the trailing ``rtncode`` parameter. Each member carries a
-    ``message`` attribute describing the condition, suitable for use in an
-    error message.
+    Produced by ``fvsSpeciesAttr``, ``fvsTreeAttr``, and sibling routines with
+    the same convention in the trailing ``rtncode`` parameter. Each member
+    carries a ``message`` attribute describing the condition, suitable for
+    use in an error message. Codes 2 and 3 are only reported by
+    ``fvsTreeAttr``; they're documented on the shared enum so a single
+    policy can cover every attr accessor.
     """
 
     message: str
 
     OK = 0, "OK"
     NAME_NOT_FOUND = 1, "name not found"
+    NTREES_EXCEEDS_MAX = 2, "ntrees is greater than the maximum allowed"
+    TREE_COUNT_MISMATCH = 3, "there were more or fewer trees than ntrees"
     NAME_LENGTH_INVALID = 4, "length of name string was too large or small"
 
     def __new__(cls, value: int, message: str) -> Self:

--- a/fvs2py/tests/test_mixins.py
+++ b/fvs2py/tests/test_mixins.py
@@ -11,12 +11,15 @@ from __future__ import annotations
 
 import ctypes as ct
 
+import numpy as np
+import pandas as pd
 import pytest
 
 from fvs2py._mixins.control import ControlMixin
 from fvs2py._mixins.simulation import SimulationMixin
 from fvs2py._mixins.species import SpeciesMixin
 from fvs2py._mixins.stand import StandMixin
+from fvs2py._mixins.trees import TreesMixin
 from fvs2py._routines import FVS_ROUTINES
 from fvs2py.common import class_requires_fvs_library, no_fvs_library_required
 from fvs2py.constants import (
@@ -31,6 +34,7 @@ from fvs2py.constants import (
     STR_NCYCLES,
     STR_NPLOTS,
     STR_NTREES,
+    TREE_ATTRS,
 )
 from fvs2py.enums import (
     FvsAttributeAccessor,
@@ -400,6 +404,113 @@ def test_species_mixin_species_attr_set_without_arr_raises_typeerror():
         TypeError, match="Must provide `arr` if `action` is 'set'"
     ):
         stub._species_attr(attr, FvsAttributeAccessor.SET, None)
+
+
+# ---------------------------------------------------------------------------
+# TreesMixin
+# ---------------------------------------------------------------------------
+
+
+class _TreesStub(TreesMixin):
+    """Minimal TreesMixin host with enough Python-side state to exercise the
+    validation branches before any call reaches :meth:`_invoke`.
+
+    The ``dims`` dict and ``species_codes`` frame are instance attributes so
+    individual tests can shape the scenario (empty stand, single-plot stand,
+    etc.) without standing up the full StandMixin/SpeciesMixin stack.
+    """
+
+    def __init__(
+        self,
+        *,
+        ntrees: int = 0,
+        maxtrees: int = 0,
+        nplots: int = 1,
+        species_indices: tuple[int, ...] = (1,),
+    ):
+        self._lib = _StubLib()
+        self._tree_attrs = TREE_ATTRS
+        self._trees = dict.fromkeys(TREE_ATTRS)
+        self.dims = {
+            STR_NTREES: ntrees,
+            STR_MAXTREES: maxtrees,
+            STR_NPLOTS: nplots,
+        }
+        self.species_codes = pd.DataFrame({"fvs_index": list(species_indices)})
+
+    def _invoke(self, name, /, **kwargs):
+        return FVS_ROUTINES[name].call(getattr(self, f"_{name}"), **kwargs)
+
+
+def test_trees_mixin_tree_attr_set_without_arr_raises_typeerror():
+    stub = _TreesStub(ntrees=3)
+    attr = next(iter(TREE_ATTRS))
+    with pytest.raises(
+        TypeError, match="Must provide `arr` if `action` is 'set'"
+    ):
+        stub._tree_attr(attr, FvsAttributeAccessor.SET, None)
+
+
+def test_trees_mixin_tree_attr_set_with_wrong_shape_raises_valueerror():
+    stub = _TreesStub(ntrees=3)
+    attr = next(iter(TREE_ATTRS))
+    with pytest.raises(ValueError, match=r"same shape as `ntrees` \(3,\)"):
+        stub._tree_attr(attr, FvsAttributeAccessor.SET, np.zeros(shape=(5,)))
+
+
+def test_trees_mixin_trees_property_warns_and_returns_none_when_empty():
+    stub = _TreesStub(ntrees=0)
+    with pytest.warns(UserWarning, match="No trees in FVS yet."):
+        assert stub.trees is None
+
+
+def test_trees_mixin_add_trees_rejects_missing_columns():
+    stub = _TreesStub(maxtrees=10, nplots=1, species_indices=(1,))
+    df = pd.DataFrame(
+        {
+            "dbh": [1.0],
+            "species": [1.0],
+            "ht": [1.0],
+            "cratio": [1.0],
+            "plot": [1.0],
+        }
+    )
+    with pytest.raises(
+        ValueError, match=r"missing required column\(s\) \['tpa'\]"
+    ):
+        stub.add_trees(df)
+
+
+def test_trees_mixin_add_trees_rejects_null_values():
+    stub = _TreesStub(maxtrees=10, nplots=1, species_indices=(1,))
+    df = pd.DataFrame(
+        {
+            "dbh": [1.0, None],
+            "species": [1.0, 1.0],
+            "ht": [1.0, 1.0],
+            "cratio": [1.0, 1.0],
+            "plot": [1.0, 1.0],
+            "tpa": [1.0, 1.0],
+        }
+    )
+    with pytest.raises(ValueError, match="No null values allowed"):
+        stub.add_trees(df)
+
+
+def test_trees_mixin_add_trees_rejects_when_no_plots_loaded():
+    stub = _TreesStub(maxtrees=10, nplots=0, species_indices=(1,))
+    df = pd.DataFrame(
+        {
+            "dbh": [1.0],
+            "species": [1.0],
+            "ht": [1.0],
+            "cratio": [1.0],
+            "plot": [1.0],
+            "tpa": [1.0],
+        }
+    )
+    with pytest.raises(RuntimeError, match="No inventory plots loaded yet."):
+        stub.add_trees(df)
 
 
 # ---------------------------------------------------------------------------

--- a/fvs2py/tests/test_routines.py
+++ b/fvs2py/tests/test_routines.py
@@ -21,6 +21,7 @@ from fvs2py._routines import (
     Param,
     Routine,
     _unwrap,
+    add_trees_policy,
     attr_accessor_policy,
     ndptr_f64,
     ndptr_intc,
@@ -83,6 +84,16 @@ def test_ndptr_intc_uses_intc_dtype():
         (int(FvsAttrReturnCode.OK), None, None),
         (int(FvsAttrReturnCode.NAME_NOT_FOUND), NameError, "name not found"),
         (
+            int(FvsAttrReturnCode.NTREES_EXCEEDS_MAX),
+            RuntimeError,
+            "ntrees is greater than the maximum allowed",
+        ),
+        (
+            int(FvsAttrReturnCode.TREE_COUNT_MISMATCH),
+            RuntimeError,
+            "more or fewer trees than ntrees",
+        ),
+        (
             int(FvsAttrReturnCode.NAME_LENGTH_INVALID),
             RuntimeError,
             "length of name string",
@@ -112,6 +123,22 @@ def test_species_code_policy_dispatches_by_return_code(rc, exc, match):
     else:
         with pytest.raises(exc, match=match):
             species_code_policy(rc)
+
+
+@pytest.mark.parametrize(
+    ("rc", "exc", "match"),
+    [
+        (0, None, None),
+        (1, ValueError, "Not enough room to store the new trees"),
+        (999, RuntimeError, "unrecognized fvsAddTrees return code"),
+    ],
+)
+def test_add_trees_policy_dispatches_by_return_code(rc, exc, match):
+    if exc is None:
+        assert add_trees_policy(rc) is None
+    else:
+        with pytest.raises(exc, match=match):
+            add_trees_policy(rc)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

New `TreesMixin` that folds both tree FVS routines (`fvsTreeAttr` and `fvsAddTrees`) into the declarative `FVS_ROUTINES` registry. This is the originally-motivating case that drove the registry work: `fvsTreeAttr` is the first migration where `ndptr_f64("ntrees")` is resolved from the call scope at every invocation, fully exercising the dynamic-type factory pattern against a buffer whose shape changes as the simulation advances. The PR also closes a gap in the attr-accessor return-code story surfaced while reading the FVS API docs for this migration.

## Changes

- `fvs2py/_mixins/trees.py` (new): `TreesMixin` with the `trees` property, `get_tree_attr` / `set_tree_attr`, the shared `_tree_attr` helper, and `add_trees`. Python-side validation for expected columns, non-nulls, existing plot codes, species codes, and max trees; the ctypes argtypes / restype plumbing is delegated to `FvsCore._invoke` via `FVS_ROUTINES["fvsTreeAttr"]` and `FVS_ROUTINES["fvsAddTrees"]`.
- `fvs2py/_routines.py`: two new `Routine` entries (`fvsTreeAttr` uses `ndptr_f64(STR_NTREES)` for the tree-sized attribute buffer and `attr_accessor_policy`; `fvsAddTrees` uses six `ndptr_f64(STR_NTREES)` factories for the per-column input arrays and the new `add_trees_policy`). `add_trees_policy` honors the documented contract (0 = OK, 1 = not enough room to store the new trees); any undocumented code raises `RuntimeError` so callers don't silently proceed.
- `fvs2py/enums.py`: `FvsAttrReturnCode` extended with `NTREES_EXCEEDS_MAX = 2` and `TREE_COUNT_MISMATCH = 3`. Codes 2 and 3 are `fvsTreeAttr`-specific but live on the shared enum so one `attr_accessor_policy` covers every attr accessor with the canonical documented message. The enum docstring now spells this out.
- `fvs2py/constants.py`: adds `TREE_ATTRS` (the tree-attribute names iterated over by the `trees` property) and `ADD_TREES_COLS` (the required columns for `add_trees`). Exposing `ADD_TREES_COLS` as a public constant gives callers a single source of truth for the `add_trees` input contract.
- `fvs2py/_base.py`: mixes `TreesMixin` into the `FVS` class and initializes `_tree_attrs` / `_trees` alongside the other per-instance buffers.
- `fvs2py/_mixins/__init__.py`: exports `TreesMixin`.
- `fvs2py/tests/test_mixins.py`: adds `_TreesStub` and six stub-based tests covering the Python-side validation branches (`_tree_attr` set-without-arr, set-with-wrong-shape; `trees` warns and returns `None` when empty; `add_trees` rejects missing columns, null values, and missing inventory plots).
- `fvs2py/tests/test_routines.py`: parametrized tests for `add_trees_policy` (OK, not-enough-room, unrecognized code) and extends the `attr_accessor_policy` parametrization to cover the two new tree-specific codes.

## Polishing the `add_trees` input contract

While migrating, two lightweight ergonomic tweaks came with the territory:

- `tree_df` stays a `pd.DataFrame` (matches how users receive inventory data from CSVs, SQL, Parquet, etc.; no new dependencies).
- `add_trees` now validates required columns explicitly before the `.astype(np.float64)` call, so a missing column raises a clear `ValueError` listing the missing names and the full expected set instead of the raw pandas `KeyError`.
- The `add_trees` docstring references `ADD_TREES_COLS` by its fully qualified name so Sphinx / IDE tooltips link to the canonical column list.

## Verification

- [x] `pytest fvs2py/tests/` — 207 passed (11 new across the mixin and routines tests).
- [x] `ruff check fvs2py/` — all checks passed.
- [x] Smoke-test against a real FVS variant to confirm end-to-end behavior: populate an inventory, call `fvs.trees`, mutate an attribute via `set_tree_attr`, insert additional trees with `add_trees`, and verify `fvs.trees` reflects both changes (optional; mechanical coverage is in the stub tests and the registry entries).