### PR TITLE
svs mixin

### DIFF
--- a/fvs2py/_base.py
+++ b/fvs2py/_base.py
@@ -12,16 +12,24 @@ from fvs2py._mixins import (
     SimulationMixin,
     SpeciesMixin,
     StandMixin,
+    SVSMixin,
     TreesMixin,
 )
 from fvs2py.common import class_requires_fvs_library
-from fvs2py.constants import EVMON_ATTRS, SPECIES_ATTRS, TREE_ATTRS
+from fvs2py.constants import (
+    EVMON_ATTRS,
+    FFE_FALLYRS_ATTRS,
+    SPECIES_ATTRS,
+    SVS_OBJ_ATTRS,
+    TREE_ATTRS,
+)
 from fvs2py.enums import FvsSimulationState
 
 
 @class_requires_fvs_library
 class FVS(
     EventMixin,
+    SVSMixin,
     TreesMixin,
     SpeciesMixin,
     StandMixin,
@@ -31,11 +39,11 @@ class FVS(
 ):
     """Main class for interacting with FVS at runtime.
 
-    Public behavior is contributed by the six mixins
-    (:class:`EventMixin`, :class:`TreesMixin`, :class:`SpeciesMixin`,
-    :class:`StandMixin`, :class:`SimulationMixin`, :class:`ControlMixin`);
-    this class just initializes the Python-side buffers they rely on and
-    wires the library-reload hook.
+    Public behavior is contributed by the seven mixins
+    (:class:`EventMixin`, :class:`SVSMixin`, :class:`TreesMixin`,
+    :class:`SpeciesMixin`, :class:`StandMixin`, :class:`SimulationMixin`,
+    :class:`ControlMixin`); this class just initializes the Python-side
+    buffers they rely on and wires the library-reload hook.
     """
 
     def __init__(self, lib_path: str | os.PathLike) -> None:
@@ -57,6 +65,8 @@ class FVS(
         self.keyfile = None
         self._evmon_attrs = dict.fromkeys(EVMON_ATTRS)
         self._exit_code = ct.c_int(0)
+        self._ffe_attrs = dict.fromkeys(FFE_FALLYRS_ATTRS)
+        self._svs_obj_attrs = dict.fromkeys(SVS_OBJ_ATTRS)
         self._itrncd = ct.c_int(-1)
         self._maxcycles = ct.c_int(0)
         self._maxplots = ct.c_int(0)

--- a/fvs2py/_mixins/__init__.py
+++ b/fvs2py/_mixins/__init__.py
@@ -11,11 +11,13 @@ from fvs2py._mixins.events import EventMixin
 from fvs2py._mixins.simulation import SimulationMixin
 from fvs2py._mixins.species import SpeciesMixin
 from fvs2py._mixins.stand import StandMixin
+from fvs2py._mixins.svs import SVSMixin
 from fvs2py._mixins.trees import TreesMixin
 
 __all__ = [
     "ControlMixin",
     "EventMixin",
+    "SVSMixin",
     "SimulationMixin",
     "SpeciesMixin",
     "StandMixin",

--- a/fvs2py/_mixins/svs.py
+++ b/fvs2py/_mixins/svs.py
@@ -1,0 +1,166 @@
+"""SVS/FFE API: ``fvsSVSDimSizes``, ``fvsSVSObjData``, and ``fvsFFEAttrs``."""
+
+from __future__ import annotations
+
+import ctypes as ct
+import warnings
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+
+from fvs2py.common import fvs_property
+from fvs2py.constants import (
+    STR_MAXSPECIES,
+    STR_NCWDOBJS,
+    STR_NDEADOBJS,
+    STR_NSVSOBJS,
+    SVS_CWD_OBJ_ATTRS,
+    SVS_LIVE_OBJ_ATTRS,
+    SVS_SNAG_OBJ_ATTRS,
+)
+from fvs2py.enums import FvsAttributeAccessor
+
+
+def _svs_nobjs_key(attr: str) -> str:
+    if attr in SVS_LIVE_OBJ_ATTRS:
+        return STR_NSVSOBJS
+    if attr in SVS_SNAG_OBJ_ATTRS:
+        return STR_NDEADOBJS
+    if attr in SVS_CWD_OBJ_ATTRS:
+        return STR_NCWDOBJS
+    msg = f"unrecognized SVS object attribute: {attr!r}"
+    raise NameError(msg)
+
+
+class SVSMixin:
+    """Stand Visualization System and related FFE per-species schedules.
+
+    This mixin groups FVS entry points used for 3D/SVS object geometry and
+    the Fire and Fuels Extension per-species snag crown fall-year vectors
+    (``fallyrs0``..``fallyrs5`` via ``fvsFFEAttrs``). FFE *stand-level*
+    compute variables (e.g. ``torchidx``, ``crbaseht``) remain in
+    :class:`fvs2py._mixins.events.EventMixin` and ``fvsEvmonAttr``.
+
+    Assumes the composed class provides :meth:`FvsCore._invoke`, ``dims``
+    from :class:`StandMixin`, and buffers ``_ffe_attrs`` and
+    ``_svs_obj_attrs`` from ``FVS._initialize_attributes``.
+    """
+
+    _invoke: Callable[..., Any]
+    _ffe_attrs: dict[str, npt.NDArray[np.float64] | None]
+    _svs_obj_attrs: dict[str, npt.NDArray[np.float64] | None]
+    dims: dict
+
+    @fvs_property
+    def svs_dim_sizes(self) -> dict[str, int]:
+        """Current and max SVS object counts from ``fvsSVSDimSizes``.
+
+        Keys: ``nsvsobjs``, ``ndeadobjs``, ``ncwdobjs`` (current counts) and
+        ``mxsvsobjs``, ``mxdeadobjs``, ``mxcwdobjs`` (capacity).
+        """
+        return self._invoke("fvsSVSDimSizes")
+
+    @fvs_property
+    def ffe_attrs(self) -> pd.DataFrame:
+        """DataFrame of per-species ``fallyrs0``..``fallyrs5`` (``fvsFFEAttrs``)."""
+        for attr in self._ffe_attrs:
+            _ = self.get_ffe_attr(attr)
+
+        attrs = pd.DataFrame(self._ffe_attrs, copy=False)
+        if (attrs == 0).all().all():
+            warnings.warn(
+                "No FFE fallyrs attributes initialized yet. "
+                "Is the Fire and Fuels Extension active in the loaded keyfile?"
+            )
+            return attrs.replace(0, None)
+
+        return attrs
+
+    def get_ffe_attr(self, attr: str) -> npt.NDArray[np.float64]:
+        """Get one ``fvsFFEAttrs`` fallyrs column (shape ``(maxspecies,)``)."""
+        self._ffe_attr(attr, FvsAttributeAccessor.GET)
+        return self._ffe_attrs[attr]
+
+    def set_ffe_attr(self, attr: str, arr: npt.NDArray[np.float64]) -> None:
+        """Set one ``fvsFFEAttrs`` fallyrs column (shape ``(maxspecies,)``)."""
+        return self._ffe_attr(attr, FvsAttributeAccessor.SET, arr)
+
+    def get_svs_obj_attr(self, attr: str) -> npt.NDArray[np.float64]:
+        """Get one ``fvsSVSObjData`` array (length = current nsvs/ndead/ncwd)."""
+        self._svs_obj_attr(attr, FvsAttributeAccessor.GET)
+        return self._svs_obj_attrs[attr]
+
+    def set_svs_obj_attr(self, attr: str, arr: npt.NDArray[np.float64]) -> None:
+        """Set one ``fvsSVSObjData`` array; shape must match current count."""
+        return self._svs_obj_attr(attr, FvsAttributeAccessor.SET, arr)
+
+    def _ffe_attr(
+        self,
+        attr: str,
+        action: FvsAttributeAccessor,
+        arr: npt.NDArray[np.float64] | None = None,
+    ) -> None:
+        if attr not in self._ffe_attrs:
+            msg = "Invalid variable requested. Valid options are"
+            raise NameError(msg, tuple(self._ffe_attrs))
+
+        dims = self.dims
+        if action == FvsAttributeAccessor.GET and self._ffe_attrs[attr] is None:
+            self._ffe_attrs[attr] = np.empty(
+                dtype=np.float64, shape=(dims[STR_MAXSPECIES],)
+            )
+        elif action == FvsAttributeAccessor.SET:
+            if arr is None:
+                msg = "Must provide `arr` if `action` is 'set'"
+                raise TypeError(msg)
+            if arr.shape != (dims[STR_MAXSPECIES],):
+                msg = (
+                    "`arr` must be same shape as `maxspecies` "
+                    f"({dims[STR_MAXSPECIES]},)"
+                )
+                raise ValueError(msg)
+            self._ffe_attrs[attr] = arr
+
+        self._invoke(
+            "fvsFFEAttrs",
+            attr_name=ct.c_char_p(attr.encode()),
+            nch=ct.c_int(len(attr)),
+            action=ct.c_char_p(action.encode()),
+            maxspecies=ct.c_int(dims[STR_MAXSPECIES]),
+            arr=self._ffe_attrs[attr],
+        )
+
+    def _svs_obj_attr(
+        self,
+        attr: str,
+        action: FvsAttributeAccessor,
+        arr: npt.NDArray[np.float64] | None = None,
+    ) -> None:
+        if attr not in self._svs_obj_attrs:
+            msg = "Invalid variable requested. Valid options are"
+            raise NameError(msg, self._svs_obj_attrs)
+
+        nkey = _svs_nobjs_key(attr)
+        n = int(self.svs_dim_sizes[nkey])
+        if action == FvsAttributeAccessor.SET:
+            if arr is None:
+                msg = "Must provide `arr` if `action` is 'set'"
+                raise TypeError(msg)
+            if arr.shape != (n,):
+                msg = f"`arr` must have shape `({n},)` for {attr!r}."
+                raise ValueError(msg)
+            self._svs_obj_attrs[attr] = arr
+        else:
+            self._svs_obj_attrs[attr] = np.empty(dtype=np.float64, shape=(n,))
+
+        self._invoke(
+            "fvsSVSObjData",
+            attr_name=ct.c_char_p(attr.encode()),
+            nch=ct.c_int(len(attr)),
+            action=ct.c_char_p(action.encode()),
+            nobjs=ct.c_int(n),
+            arr=self._svs_obj_attrs[attr],
+        )

--- a/fvs2py/_routines.py
+++ b/fvs2py/_routines.py
@@ -30,8 +30,15 @@ from fvs2py.constants import (
     STR_MAXPLOTS,
     STR_MAXSPECIES,
     STR_MAXTREES,
+    STR_MXCWDOBJS,
+    STR_MXDEADOBJS,
+    STR_MXSVSOBJS,
+    STR_NCWDOBJS,
     STR_NCYCLES,
+    STR_NDEADOBJS,
+    STR_NOBJS,
     STR_NPLOTS,
+    STR_NSVSOBJS,
     STR_NTREES,
 )
 from fvs2py.enums import FvsAttrReturnCode
@@ -508,6 +515,79 @@ _RAW_ROUTINES: dict[str, Routine] = {
             Param(
                 name="arr",
                 ctype=ndptr_f64(STR_NTREES),
+                intent=Intent.INOUT,
+            ),
+            Param(
+                name="rtncode",
+                ctype=ct.POINTER(ct.c_int),
+                intent=Intent.OUT,
+            ),
+        ),
+        rc_policy=attr_accessor_policy,
+    ),
+    "fvsFFEAttrs": Routine(
+        params=(
+            Param(name="attr_name", ctype=ct.c_char_p),
+            Param(name="nch", ctype=ct.POINTER(ct.c_int)),
+            Param(name="action", ctype=ct.c_char_p),
+            Param(name=STR_MAXSPECIES, ctype=ct.POINTER(ct.c_int)),
+            Param(
+                name="arr",
+                ctype=ndptr_f64(STR_MAXSPECIES),
+                intent=Intent.INOUT,
+            ),
+            Param(
+                name="rtncode",
+                ctype=ct.POINTER(ct.c_int),
+                intent=Intent.OUT,
+            ),
+        ),
+        rc_policy=attr_accessor_policy,
+    ),
+    "fvsSVSDimSizes": Routine(
+        params=(
+            Param(
+                name=STR_NSVSOBJS,
+                ctype=ct.POINTER(ct.c_int),
+                intent=Intent.OUT,
+            ),
+            Param(
+                name=STR_NDEADOBJS,
+                ctype=ct.POINTER(ct.c_int),
+                intent=Intent.OUT,
+            ),
+            Param(
+                name=STR_NCWDOBJS,
+                ctype=ct.POINTER(ct.c_int),
+                intent=Intent.OUT,
+            ),
+            Param(
+                name=STR_MXSVSOBJS,
+                ctype=ct.POINTER(ct.c_int),
+                intent=Intent.OUT,
+            ),
+            Param(
+                name=STR_MXDEADOBJS,
+                ctype=ct.POINTER(ct.c_int),
+                intent=Intent.OUT,
+            ),
+            Param(
+                name=STR_MXCWDOBJS,
+                ctype=ct.POINTER(ct.c_int),
+                intent=Intent.OUT,
+            ),
+        ),
+        rc_param=None,
+    ),
+    "fvsSVSObjData": Routine(
+        params=(
+            Param(name="attr_name", ctype=ct.c_char_p),
+            Param(name="nch", ctype=ct.POINTER(ct.c_int)),
+            Param(name="action", ctype=ct.c_char_p),
+            Param(name=STR_NOBJS, ctype=ct.POINTER(ct.c_int)),
+            Param(
+                name="arr",
+                ctype=ndptr_f64(STR_NOBJS),
                 intent=Intent.INOUT,
             ),
             Param(

--- a/fvs2py/constants.py
+++ b/fvs2py/constants.py
@@ -1,4 +1,5 @@
 STR_C_CONTIGUOUS = "C_CONTIGUOUS"
+# core forest vegetation simulator attribute names
 STR_MAXCYCLES = "maxcycles"
 STR_MAXPLOTS = "maxplots"
 STR_MAXSPECIES = "maxspecies"
@@ -6,6 +7,14 @@ STR_MAXTREES = "maxtrees"
 STR_NCYCLES = "ncycles"
 STR_NPLOTS = "nplots"
 STR_NTREES = "ntrees"
+# stand visualization system attribute names
+STR_NSVSOBJS = "nsvsobjs"
+STR_NDEADOBJS = "ndeadobjs"
+STR_NCWDOBJS = "ncwdobjs"
+STR_MXSVSOBJS = "mxsvsobjs"
+STR_MXDEADOBJS = "mxdeadobjs"
+STR_MXCWDOBJS = "mxcwdobjs"
+STR_NOBJS = "nobjs"
 
 STAND_CN_COLUMN_NAME = "stand_cn"
 STAND_ID_COLUMN_NAME = "stand_id"
@@ -107,6 +116,47 @@ SPECIES_ATTRS = (
     "spccf",
     "spsdi",
     "spsiteindx",
+)
+
+FFE_FALLYRS_ATTRS = (
+    "fallyrs0",
+    "fallyrs1",
+    "fallyrs2",
+    "fallyrs3",
+    "fallyrs4",
+    "fallyrs5",
+)
+
+# ``fvsSVSObjData`` (live 3D objects, standing dead snags, and coarse
+# woody debris). Length of each array is the corresponding current
+# count from ``fvsSVSDimSizes``.
+SVS_LIVE_OBJ_ATTRS = (
+    "objtype",
+    "objindex",
+    "xloc",
+    "yloc",
+)
+SVS_SNAG_OBJ_ATTRS = (
+    "snagdbh",
+    "snaglen",
+    "snagyear",
+    "snagspp",
+    "snagfdir",
+    "snagstat",
+    "snagwt0",
+    "snagwt1",
+    "snagwt2",
+    "snagwt3",
+)
+SVS_CWD_OBJ_ATTRS = (
+    "cwddia",
+    "cwdlen",
+    "cwdpil",
+    "cwddir",
+    "cwdwt",
+)
+SVS_OBJ_ATTRS: tuple[str, ...] = (
+    SVS_LIVE_OBJ_ATTRS + SVS_SNAG_OBJ_ATTRS + SVS_CWD_OBJ_ATTRS
 )
 
 EVMON_ATTRS = (

--- a/fvs2py/tests/test_mixins.py
+++ b/fvs2py/tests/test_mixins.py
@@ -20,11 +20,13 @@ from fvs2py._mixins.events import EventMixin
 from fvs2py._mixins.simulation import SimulationMixin
 from fvs2py._mixins.species import SpeciesMixin
 from fvs2py._mixins.stand import StandMixin
+from fvs2py._mixins.svs import SVSMixin
 from fvs2py._mixins.trees import TreesMixin
 from fvs2py._routines import FVS_ROUTINES
 from fvs2py.common import class_requires_fvs_library, no_fvs_library_required
 from fvs2py.constants import (
     EVMON_ATTRS,
+    FFE_FALLYRS_ATTRS,
     MGMT_ID_COLUMN_NAME,
     SPECIES_ATTRS,
     STAND_CN_COLUMN_NAME,
@@ -33,9 +35,16 @@ from fvs2py.constants import (
     STR_MAXPLOTS,
     STR_MAXSPECIES,
     STR_MAXTREES,
+    STR_MXCWDOBJS,
+    STR_MXDEADOBJS,
+    STR_MXSVSOBJS,
+    STR_NCWDOBJS,
     STR_NCYCLES,
+    STR_NDEADOBJS,
     STR_NPLOTS,
+    STR_NSVSOBJS,
     STR_NTREES,
+    SVS_OBJ_ATTRS,
     TREE_ATTRS,
 )
 from fvs2py.enums import (
@@ -407,6 +416,202 @@ def test_species_mixin_species_attr_set_without_arr_raises_typeerror():
         TypeError, match="Must provide `arr` if `action` is 'set'"
     ):
         stub._species_attr(attr, FvsAttributeAccessor.SET, None)
+
+
+# ---------------------------------------------------------------------------
+# SVSMixin (fvsSVSDimSizes, fvsSVSObjData, fvsFFEAttrs)
+# ---------------------------------------------------------------------------
+
+
+class _SVSStub(SVSMixin):
+    """Host for :class:`SVSMixin` with Python stubs for the three FVS entry points."""
+
+    def __init__(
+        self,
+        *,
+        maxspecies: int = 3,
+        known_ffe: dict[str, np.ndarray] | None = None,
+        svs_counts: dict[str, int] | None = None,
+    ):
+        sc = svs_counts or {
+            STR_NSVSOBJS: 2,
+            STR_NDEADOBJS: 1,
+            STR_NCWDOBJS: 1,
+            STR_MXSVSOBJS: 100,
+            STR_MXDEADOBJS: 100,
+            STR_MXCWDOBJS: 100,
+        }
+        self._lib = _StubLib()
+        self._ffe_attrs = dict.fromkeys(FFE_FALLYRS_ATTRS)
+        self._svs_obj_attrs = dict.fromkeys(SVS_OBJ_ATTRS)
+        self.dims = {STR_MAXSPECIES: maxspecies}
+        self._known_ffe: dict[str, np.ndarray] = known_ffe or {}
+        self._known_svs: dict[str, np.ndarray] = {}
+        self.ffe_calls: list[dict] = []
+        self.svs_obj_calls: list[dict] = []
+        self._sc = sc
+
+        def fvs_svs_dim_sizes(nsv, nde, ncw, mxn, mxd, mxc):
+            nsv.value = sc[STR_NSVSOBJS]
+            nde.value = sc[STR_NDEADOBJS]
+            ncw.value = sc[STR_NCWDOBJS]
+            mxn.value = sc[STR_MXSVSOBJS]
+            mxd.value = sc[STR_MXDEADOBJS]
+            mxc.value = sc[STR_MXCWDOBJS]
+
+        def fvs_ffe_attrs(attr_name, nch, action, maxspecies_ptr, arr, rtncode):
+            name = bytes(ct.string_at(attr_name, nch.value)).decode()
+            act = bytes(ct.string_at(action, 3)).decode()
+            n = maxspecies_ptr.value
+            self.ffe_calls.append(
+                {"name": name, "action": act, "maxspecies": n}
+            )
+            if name not in FFE_FALLYRS_ATTRS:
+                rtncode.value = 1
+                return
+            if n != self.dims[STR_MAXSPECIES]:
+                rtncode.value = 3
+                return
+            if act == "get":
+                stored = self._known_ffe.get(name)
+                if stored is None:
+                    arr[:] = np.zeros(n, dtype=np.float64)
+                else:
+                    arr[:] = stored
+            else:
+                self._known_ffe[name] = np.array(arr, dtype=np.float64)
+            rtncode.value = 0
+
+        def fvs_svs_obj_data(attr_name, nch, action, nobjs, arr, rtncode):
+            name = bytes(ct.string_at(attr_name, nch.value)).decode()
+            act = bytes(ct.string_at(action, 3)).decode()
+            n = nobjs.value
+            self.svs_obj_calls.append({"name": name, "action": act, "nobjs": n})
+            if name not in SVS_OBJ_ATTRS:
+                rtncode.value = 1
+                return
+            if act == "get":
+                if name in self._known_svs:
+                    arr[:] = self._known_svs[name]
+                else:
+                    arr[:] = np.arange(n, dtype=np.float64)
+            else:
+                self._known_svs[name] = np.array(arr, dtype=np.float64).copy()
+            rtncode.value = 0
+
+        self._fvsSVSDimSizes = fvs_svs_dim_sizes
+        self._fvsFFEAttrs = fvs_ffe_attrs
+        self._fvsSVSObjData = fvs_svs_obj_data
+
+    def _invoke(self, name, /, **kwargs):
+        return FVS_ROUTINES[name].call(getattr(self, f"_{name}"), **kwargs)
+
+
+def test_svs_mixin_svs_dim_sizes_returns_six_ints():
+    stub = _SVSStub()
+    d = stub.svs_dim_sizes
+    assert d[STR_NSVSOBJS] == 2
+    assert d[STR_NDEADOBJS] == 1
+    assert d[STR_NCWDOBJS] == 1
+    assert d[STR_MXSVSOBJS] == 100
+
+
+def test_svs_mixin_ffe_attr_unknown_name_raises_nameerror():
+    stub = _SVSStub()
+    with pytest.raises(NameError, match="Invalid variable requested"):
+        stub._ffe_attr("not-a-real-attr", FvsAttributeAccessor.GET)
+
+
+def test_svs_mixin_svs_obj_attr_unknown_name_raises_nameerror():
+    stub = _SVSStub()
+    with pytest.raises(NameError, match="Invalid variable requested"):
+        stub._svs_obj_attr("nope", FvsAttributeAccessor.GET)
+
+
+def test_svs_mixin_ffe_attr_set_without_arr_raises_typeerror():
+    stub = _SVSStub()
+    attr = next(iter(FFE_FALLYRS_ATTRS))
+    with pytest.raises(
+        TypeError, match="Must provide `arr` if `action` is 'set'"
+    ):
+        stub._ffe_attr(attr, FvsAttributeAccessor.SET, None)
+
+
+def test_svs_mixin_ffe_attr_set_with_wrong_shape_raises_valueerror():
+    stub = _SVSStub(maxspecies=3)
+    attr = next(iter(FFE_FALLYRS_ATTRS))
+    with pytest.raises(ValueError, match=r"same shape as `maxspecies` \(3,\)"):
+        stub._ffe_attr(attr, FvsAttributeAccessor.SET, np.zeros(shape=(5,)))
+
+
+def test_svs_mixin_get_ffe_attr_round_trips_through_stub():
+    attr = next(iter(FFE_FALLYRS_ATTRS))
+    values = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    stub = _SVSStub(maxspecies=3, known_ffe={attr: values})
+    out = stub.get_ffe_attr(attr)
+    assert out.tolist() == [1.0, 2.0, 3.0]
+    assert stub.ffe_calls[-1] == {
+        "name": attr,
+        "action": "get",
+        "maxspecies": 3,
+    }
+
+
+def test_svs_mixin_set_ffe_attr_round_trips_through_stub():
+    attr = next(iter(FFE_FALLYRS_ATTRS))
+    stub = _SVSStub(maxspecies=3)
+    stub.set_ffe_attr(attr, np.array([10.0, 20.0, 30.0], dtype=np.float64))
+    assert stub._known_ffe[attr].tolist() == [10.0, 20.0, 30.0]
+    assert stub.ffe_calls[-1] == {
+        "name": attr,
+        "action": "set",
+        "maxspecies": 3,
+    }
+    assert stub.get_ffe_attr(attr).tolist() == [10.0, 20.0, 30.0]
+
+
+def test_svs_mixin_get_svs_obj_attr_live():
+    # Default _SVSStub: 2 live, 1 dead, 1 cwd (``xloc`` is length nsvsobjs).
+    stub = _SVSStub()
+    out = stub.get_svs_obj_attr("xloc")
+    assert out.tolist() == [0.0, 1.0]
+    assert stub.svs_obj_calls[-1]["name"] == "xloc"
+    assert stub.svs_obj_calls[-1]["nobjs"] == 2
+
+
+def test_svs_mixin_svs_obj_set_get_round_trip():
+    stub = _SVSStub()
+    v = np.array([3.0, 4.0], dtype=np.float64)
+    stub.set_svs_obj_attr("xloc", v)
+    assert stub.get_svs_obj_attr("xloc").tolist() == [3.0, 4.0]
+
+
+@pytest.mark.parametrize("attr", FFE_FALLYRS_ATTRS)
+def test_svs_mixin_ffe_fallyrs_get_set_round_trip(attr):
+    stub = _SVSStub(maxspecies=4)
+    vals = np.array([1.5, 2.5, 3.5, 4.5], dtype=np.float64)
+    stub.set_ffe_attr(attr, vals)
+    assert stub.get_ffe_attr(attr).tolist() == vals.tolist()
+
+
+def test_svs_mixin_ffe_attrs_property_warns_when_all_zero():
+    stub = _SVSStub(maxspecies=2)
+    with pytest.warns(
+        UserWarning, match="No FFE fallyrs attributes initialized yet"
+    ):
+        result = stub.ffe_attrs
+    assert list(result.columns) == list(FFE_FALLYRS_ATTRS)
+    assert result.shape == (2, len(FFE_FALLYRS_ATTRS))
+    assert result.isna().all().all()
+
+
+def test_svs_mixin_ffe_attrs_property_returns_populated_frame():
+    attr = FFE_FALLYRS_ATTRS[0]
+    values = np.array([7.0, 8.0], dtype=np.float64)
+    stub = _SVSStub(maxspecies=2, known_ffe={attr: values})
+    result = stub.ffe_attrs
+    assert list(result.columns) == list(FFE_FALLYRS_ATTRS)
+    assert result[attr].tolist() == [7.0, 8.0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR consolidates three FVS API entrypoints utilized for stand visualization into a single `SVSMixin`:
- `fvsSVSDimSizes`
- `fvsSVSObjData`
- `fvsFFEAttrs`

## What Changed
- Added routine registry entries for `fvsSVSDimSizes`, `fvsFFEAttrs` and `fvsSVSObjData` in `fvs2py/_routines.py`
- Added SVS-related constants in `fvs2py/constants.py`:
  - SVS dim-size keys (`nsvsobjs`, `ndeadobjs`, `ncwdobjs`, `mxsvsobjs`, `mxdeadobjs`, `mxcwdobjs`, `nobjs`)
  - SVS object attribute groupings (`SVS_LIVE_OBJ_ATTRS`, `SVS_SNAG_OBJ_ATTRS`, `SVS_CWD_OBJ_ATTRS`, `SVS_OBJ_ATTRS`)
- Added new `fvs2py/_mixins/svs.py` with:
  - `svs_dim_sizes` property (`fvsSVSDimSizes`)
  - `get_svs_obj_attr` / `set_svs_obj_attr` (`fvsSVSObjData`)
  - `get_ffe_attr` / `set_ffe_attr` / `ffe_attrs` (`fvsFFEAttrs`)
- Updated tests in `fvs2py/tests/test_mixins.py` to use `_SVSStub(SVSMixin)` and cover SVS+FFE behavior

## Behavior Notes
- `fvsSVSObjData` validates expected vector length based on attribute group (`NSVOBJ`, `NDEAD`, `NCWD`) derived from `svs_dim_sizes`.
- FFE `fallyrs0..fallyrs5` remain modeled as per-species vectors (`maxspecies`) and surfaced through `SVSMixin`.

## Test Plan
New stub and suite of unit tests added to ensure SVSMixin behaves as expected. All pass.