### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,8 @@
 name: Lint
 
 on: [pull_request]
+permissions:
+  contents: read
 jobs:
   lint:
     name: Lint and secret scan


### PR DESCRIPTION
Potential fix for [https://github.com/Vibrant-Planet-Open-Science/fvs2py/security/code-scanning/5](https://github.com/Vibrant-Planet-Open-Science/fvs2py/security/code-scanning/5)

Add an explicit `permissions` block to `.github/workflows/lint.yml` at the workflow root so it applies to all jobs unless overridden. For this workflow, the best minimal non-breaking fix is:

- `contents: read`

This aligns with CodeQL’s recommendation and supports `actions/checkout` while enforcing least privilege. No imports, methods, or dependencies are needed; this is a YAML configuration-only change near the top of the file, directly under `on:` (or above `jobs:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
