### PR TITLE
drop lib prefix from shared libraries

### DIFF
--- a/examples/Basic fvs2py Demonstration.ipynb
+++ b/examples/Basic fvs2py Demonstration.ipynb
@@ -54,7 +54,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fvs = FVS(f\"/usr/local/lib/libFVS{variant.lower()}.so\")"
+    "fvs = FVS(f\"/usr/local/lib/FVS{variant.lower()}.so\")"
    ]
   },
   {
@@ -1775,13 +1775,13 @@
      "text": [
       "\n",
       "\n",
-      "     FOREST VEGETATION SIMULATOR     VERSION FS2025.4 -- INLAND EMPIRE EXPANDED                 RV:20250930    05-23-2026  05:23:38\n",
+      "     FOREST VEGETATION SIMULATOR     VERSION FS2026.1 -- INLAND EMPIRE EXPANDED                 RV:20260401    05-23-2026  08:51:54\n",
       "\n",
       "----------------------------------------------------------------------------------------------------------------------------------\n",
       "\n",
       "                                                OPTIONS SELECTED BY INPUT\n",
       "\n",
-      "KEYWORD FILE NAME: /tmp/tmpeouhnlj2/example_keyfile\n",
+      "KEYWORD FILE NAME: /tmp/tmpnj77einy/example_keyfile\n",
       "----------------------------------------------------------------------------------------------------------------------------------\n",
       "KEYWORD    PARAMETERS:\n",
       "--------   -----------------------------------------------------------------------------------------------------------------------\n",
@@ -1914,7 +1914,7 @@
       "NUMBER OF RECORDS WITH MISTLETOE                   0\n",
       "\n",
       "\n",
-      "     FOREST VEGETATION SIMULATOR     VERSION FS2025.4 -- INLAND EMPIRE EXPANDED                 RV:20250930    05-23-2026  05:23:38\n",
+      "     FOREST VEGETATION SIMULATOR     VERSION FS2026.1 -- INLAND EMPIRE EXPANDED                 RV:20260401    05-23-2026  08:51:54\n",
       "\n",
       "STAND ID: 12345                         MGMT ID: NONE    TEST\n",
       "\n",
@@ -2068,7 +2068,7 @@
       "        MERCH        18.5   21.2   22.3   22.6   25.6    25.6   33712. BDFT      90.% OS1,   9.% PP1,   1.% DF1,   0.% LP1\n",
       "\n",
       "\n",
-      "     FOREST VEGETATION SIMULATOR     VERSION FS2025.4 -- INLAND EMPIRE EXPANDED                 RV:20250930    05-23-2026  05:23:38\n",
+      "     FOREST VEGETATION SIMULATOR     VERSION FS2026.1 -- INLAND EMPIRE EXPANDED                 RV:20260401    05-23-2026  08:51:54\n",
       "\n",
       "STAND ID: 12345                         MGMT ID: NONE    TEST\n",
       "\n",
@@ -2194,7 +2194,7 @@
       "** NOTE:  DUE TO HARVEST, COMPRESSION, OR REGENERATION ESTABLISHMENT, NEW SAMPLE TREES WERE SELECTED.\n",
       "\n",
       "\n",
-      "     FOREST VEGETATION SIMULATOR     VERSION FS2025.4 -- INLAND EMPIRE EXPANDED                 RV:20250930    05-23-2026  05:23:38\n",
+      "     FOREST VEGETATION SIMULATOR     VERSION FS2026.1 -- INLAND EMPIRE EXPANDED                 RV:20260401    05-23-2026  08:51:54\n",
       "\n",
       "STAND ID: 12345                         MGMT ID: NONE    TEST\n",
       "\n",

--- a/fvs2py/tests/test_base.py
+++ b/fvs2py/tests/test_base.py
@@ -25,7 +25,7 @@ from fvs2py.enums import (
     FvsVariant,
 )
 
-TEST_DLL = "/usr/local/lib/libFVSso.so"
+TEST_DLL = "/usr/local/lib/FVSso.so"
 TEST_KEYFILE_PATH = importlib.resources.files("fvs2py.tests.keyfiles").joinpath(
     "SO.key"
 )
@@ -321,7 +321,7 @@ def test_summary(fvs, keyfile):
 
 @pytest.mark.parametrize("variant", FvsVariant)
 def test_species_codes(variant):
-    fvs = FVS(f"/usr/local/lib/libFVS{variant.lower()}.so")
+    fvs = FVS(f"/usr/local/lib/FVS{variant.lower()}.so")
     dims = fvs.dims
     max_species = dims[STR_MAXSPECIES]
 
@@ -332,7 +332,7 @@ def test_species_codes(variant):
 
 @pytest.mark.parametrize("variant", FvsVariant)
 def test_species_attrs(variant, keyfile, recwarn):
-    fvs = FVS(f"/usr/local/lib/libFVS{variant.lower()}.so")
+    fvs = FVS(f"/usr/local/lib/FVS{variant.lower()}.so")
 
     # warning should be raised if run hasn't been started
     fvs.species_attrs


### PR DESCRIPTION
After change in base image, renaming shared library pattern to remove lib prefix.