### PR TITLE
chore: tidies up dockerfile a bit, adds uv.lock check to pytest, and bumps test actions to Node 24

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -6,7 +6,7 @@ permissions:
   contents: read
 
 env:
-  FVS_TAG: FS2026.1
+  FVS_TAG: FS2026.2
   CI_IMAGE: fvs2py-ci:dev
 
 jobs:
@@ -15,9 +15,16 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
 
-      - uses: docker/build-push-action@v6
+      - name: Check uv.lock is up to date
+        run: uv lock --check
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/build-push-action@v7
         with:
           context: .
           target: dev
@@ -87,10 +94,10 @@ jobs:
 
           echo "skip=false" >> "${GITHUB_OUTPUT}"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
         if: steps.notebooks.outputs.skip != 'true'
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         if: steps.notebooks.outputs.skip != 'true'
         with:
           context: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,27 @@
-ARG FVS_TAG=FS2026.1
+ARG FVS_TAG=FS2026.2
 ARG FVS_IMAGE=ghcr.io/vibrant-planet-open-science/usfs-fvs:${FVS_TAG}
 
-FROM ${FVS_IMAGE} AS fvs-python-base
+FROM ${FVS_IMAGE} AS base
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
+    && apt-get upgrade -y --no-install-recommends \
     && apt-get install -y --no-install-recommends \
     python3 \
-    python3-venv \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /uvx /bin/
 
-FROM fvs-python-base AS runtime-base
-ENV UV_PROJECT_ENVIRONMENT=/opt/venv
-RUN uv venv /opt/venv
-ENV PATH="/opt/venv/bin:$PATH" \
-    VIRTUAL_ENV="/opt/venv"
-
-FROM runtime-base AS fvs2py
+FROM base AS runtime
+ENV UV_PROJECT_ENVIRONMENT=/opt/venv \
+    VIRTUAL_ENV=/opt/venv \
+    PATH="/opt/venv/bin:$PATH"
 WORKDIR /workspaces/fvs2py
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project
 COPY fvs2py ./fvs2py
-COPY pyproject.toml README.md LICENSE ./
-RUN uv pip install --no-deps -e .
+COPY README.md LICENSE ./
+RUN uv sync --frozen --no-dev
 
-FROM fvs-python-base AS dev
+FROM base AS dev
 RUN if id -u ubuntu >/dev/null 2>&1; then \
     usermod -l fvs2py-dev ubuntu \
     && groupmod -n fvs2py-dev ubuntu \


### PR DESCRIPTION
## Description
Simplifies Dockerfile while maintaining same functionality. Adds check for current uv.lock to pytest. Bumps actions in test workflow to use Node 24 versions.

## Testing
Existing test workflow should pass.