### PR TITLE
ci: adds check for PR titles to follow conventional commits

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,18 @@
 name: Lint
 
-on: [pull_request]
+on: 
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
 permissions:
   contents: read
+  pull-requests: read
+
 jobs:
   lint:
     name: Lint and secret scan
@@ -24,3 +34,13 @@ jobs:
             ${{ runner.os }}-pre-commit-
 
       - uses: pre-commit/action@v3.0.1
+
+  pr-title:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          validateSingleCommit: false


### PR DESCRIPTION
## Description
Adds linting to enforce [Conventional Commit](https://www.conventionalcommits.org) format in PR titles. This coincides with updating of repo settings to enforce squash merging using only the PR title to derive the commit message. This is intended to facilitate the adoption of release-please for automating semantic versioning and releases.

## Testing
Updated workflow should run and pass on this PR.