### PR TITLE
ci: removes container publishing steps from release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,12 +1,10 @@
 name: Release
 
-# Release Please drives versioning from Conventional Commit messages. On every
-# push to main it maintains a "Release PR" that accumulates the changelog and
-# the next semver bump. Merging that Release PR creates the GitHub release +
-# git tag, which in turn gates the build-and-publish jobs below.
-#
-# Publishing runs ONLY when a release is created — never on ordinary pushes and
-# never on pull_request.
+# Release Please drives versioning from Conventional Commit formatting of PR 
+# titles. On every push to main it checks for changes that would trigger any 
+# version bump and when detected, opens and maintains a "Release PR" that 
+# accumulates the changelog and the next semver bump. Merging that Release PR 
+# creates the GitHub release + git tag, and is used to gate publishing to PyPI.
 
 on:
   push:
@@ -14,21 +12,15 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: release-${{ github.ref }}
-  cancel-in-progress: false
-
-env:
-  FVS_TAG: FS2026.2
-  GHCR_IMAGE: ghcr.io/vibrant-planet-open-science/fvs2py
-  LOCAL_IMAGE: fvs2py:publish
-
 jobs:
   release-please:
     runs-on: ubuntu-latest
     permissions:
-      contents: write        # create the release + tag, commit the Release PR
+      contents: write         # create the release + tag, commit the Release PR
       pull-requests: write    # open/update the Release PR
+    concurrency:
+      group: release-please-${{ github.ref }}
+      cancel-in-progress: false
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -40,72 +32,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-  # Gate: run the test suite against the exact release tree before publishing.
-  test:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: docker/setup-buildx-action@v4
-
-      - uses: docker/build-push-action@v7
-        with:
-          context: .
-          target: dev
-          tags: fvs2py-ci:dev
-          load: true
-          build-args: FVS_TAG=${{ env.FVS_TAG }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Run tests inside dev image
-        run: |
-          docker run --rm \
-            -v "${{ github.workspace }}:/workspaces/fvs2py" \
-            -w /workspaces/fvs2py \
-            -e PYTHONPATH=/workspaces/fvs2py \
-            fvs2py-ci:dev \
-            bash -c 'uv sync --frozen --extra dev && uv run pytest .'
-
-  publish:
-    needs: [release-please, test]
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write   # push to GHCR
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: docker/setup-buildx-action@v4
-
-      # Build the deployable image once (linux/amd64 for ECS Fargate) and load
-      # it locally so we can smoke-test the exact artifact we push.
-      - uses: docker/build-push-action@v7
-        with:
-          context: .
-          target: runtime
-          platforms: linux/amd64
-          tags: ${{ env.LOCAL_IMAGE }}
-          load: true
-          build-args: FVS_TAG=${{ env.FVS_TAG }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Tag and push to GHCR
-        env:
-          VERSION_TAG: ${{ needs.release-please.outputs.tag_name }}
-        run: |
-          set -euo pipefail
-          short_sha="$(git rev-parse --short=7 HEAD)"
-          tags="${VERSION_TAG} sha-${short_sha} latest"
-          for tag in ${tags}; do
-            docker tag "${LOCAL_IMAGE}" "${repo}:${tag}"
-            docker push "${repo}:${tag}"
-          done
-          echo "Published tags: ${tags}"


### PR DESCRIPTION
Removes the `publish` stage from the release-please workflow, as no containerized distribution of `fvs2py` is needed. Distribution of this library will be enabled through PyPI rather than GHCR. Those workflows are not covered in this PR.